### PR TITLE
fixes access on research doors (Sulaco)

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -6551,8 +6551,7 @@
 /area/sulaco/command/eva)
 "aFW" = (
 /obj/machinery/door/airlock/mainship/research/pen{
-	dir = 8;
-	req_access = list(14)
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -8472,7 +8471,6 @@
 	desc = "It opens and closes. This particular door appears hardended against Acid substances.";
 	dir = 1;
 	max_integrity = 1000;
-	req_access = list(14);
 	resistance_flags = 2
 	},
 /obj/machinery/door/poddoor/shutters/mainship/cell/cell1{
@@ -8482,9 +8480,7 @@
 /area/sulaco/research)
 "aSa" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mainship/research{
-	req_access = list(14)
-	},
+/obj/machinery/door/airlock/mainship/research,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
@@ -8580,8 +8576,7 @@
 "aSE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mainship/research{
-	dir = 2;
-	req_access = list(14)
+	dir = 2
 	},
 /obj/machinery/door/poddoor/shutters/opened/medbay{
 	dir = 2;

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -6551,7 +6551,8 @@
 /area/sulaco/command/eva)
 "aFW" = (
 /obj/machinery/door/airlock/mainship/research/pen{
-	dir = 8
+	dir = 8;
+	req_access = list(14)
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -8471,6 +8472,7 @@
 	desc = "It opens and closes. This particular door appears hardended against Acid substances.";
 	dir = 1;
 	max_integrity = 1000;
+	req_access = list(14);
 	resistance_flags = 2
 	},
 /obj/machinery/door/poddoor/shutters/mainship/cell/cell1{
@@ -8480,7 +8482,9 @@
 /area/sulaco/research)
 "aSa" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mainship/research,
+/obj/machinery/door/airlock/mainship/research{
+	req_access = list(14)
+	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
@@ -8576,7 +8580,8 @@
 "aSE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mainship/research{
-	dir = 2
+	dir = 2;
+	req_access = list(14)
 	},
 /obj/machinery/door/poddoor/shutters/opened/medbay{
 	dir = 2;

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -543,15 +543,15 @@
 	req_access = list(ACCESS_MARINE_RESEARCH)
 
 /obj/machinery/door/airlock/mainship/medical/rebel/glass/research
-	req_access = list(ACCESS_MARINE_RESEARCH)
+	req_access = list(ACCESS_MARINE_RESEARCH_REBEL)
 
 /obj/machinery/door/airlock/mainship/research
 	name = "\improper Research Airlock"
 	icon = 'icons/obj/doors/mainship/medidoor.dmi'
 	req_access = list(ACCESS_MARINE_RESEARCH)
 
-/obj/machinery/door/airlock/mainship/research
-	req_access = list(ACCESS_MARINE_RESEARCH)
+/obj/machinery/door/airlock/mainship/rebel/research
+	req_access = list(ACCESS_MARINE_RESEARCH_REBEL)
 
 /obj/machinery/door/airlock/mainship/research/free_access
 	req_access = null

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -340,7 +340,7 @@
 	icon = 'icons/obj/doors/mainship/securedoor.dmi'
 	req_access = list(ACCESS_MARINE_BRIDGE)
 
-/obj/machinery/door/airlock/mainship/secure/rebel 
+/obj/machinery/door/airlock/mainship/secure/rebel
 	req_access = list(ACCESS_MARINE_BRIDGE_REBEL)
 
 /obj/machinery/door/airlock/mainship/secure/free_access
@@ -543,7 +543,7 @@
 	req_access = list(ACCESS_MARINE_RESEARCH)
 
 /obj/machinery/door/airlock/mainship/medical/rebel/glass/research
-	req_access = list(ACCESS_MARINE_RESEARCH_REBEL)
+	req_access = list(ACCESS_MARINE_RESEARCH)
 
 /obj/machinery/door/airlock/mainship/research
 	name = "\improper Research Airlock"
@@ -551,7 +551,7 @@
 	req_access = list(ACCESS_MARINE_RESEARCH)
 
 /obj/machinery/door/airlock/mainship/research
-	req_access = list(ACCESS_MARINE_RESEARCH_REBEL)
+	req_access = list(ACCESS_MARINE_RESEARCH)
 
 /obj/machinery/door/airlock/mainship/research/free_access
 	req_access = null
@@ -676,7 +676,7 @@
 	opacity = FALSE
 	glass = TRUE
 
-/obj/machinery/door/airlock/mainship/marine/general/sl/rebel 
+/obj/machinery/door/airlock/mainship/marine/general/sl/rebel
 	req_access = list(ACCESS_MARINE_LEADER_REBEL)
 
 /obj/machinery/door/airlock/mainship/marine/general/spec

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -550,7 +550,7 @@
 	icon = 'icons/obj/doors/mainship/medidoor.dmi'
 	req_access = list(ACCESS_MARINE_RESEARCH)
 
-/obj/machinery/door/airlock/mainship/rebel/research
+/obj/machinery/door/airlock/mainship/research/rebel
 	req_access = list(ACCESS_MARINE_RESEARCH_REBEL)
 
 /obj/machinery/door/airlock/mainship/research/free_access


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Certain doors in Sulaco research was labelled with access 314, which is for a rebel researcher.  It has been changed to the proper 14.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This provides access to researchers into their department, as one would expect.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Fixes research doors in Sulaco
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
