### PR TITLE
Stopgap - Removal of acid turrets + dead bodies on maps

### DIFF
--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -321,11 +321,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/barren/cave/lz2)
-"bE" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/dark2,
-/area/barren/engie/engine)
 "bF" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 1
@@ -553,10 +548,6 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/general_offices)
-"cQ" = (
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/tile/red,
-/area/barren/security)
 "cR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/vault{
@@ -1035,7 +1026,6 @@
 "eV" = (
 /obj/machinery/bodyscanner,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 10
 	},
@@ -1226,11 +1216,6 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/closed/wall,
 /area/barren/medical/research)
-"fZ" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/lavaland/basalt,
-/area/barren/cave/south)
 "gb" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor,
@@ -1375,11 +1360,6 @@
 "gC" = (
 /turf/closed/wall,
 /area/barren/cave/north)
-"gD" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/sterilewhite,
-/area/barren/medical/research)
 "gE" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/plating/mainship,
@@ -1817,7 +1797,6 @@
 /area/barren/cave/northwest)
 "iH" = (
 /obj/item/storage/firstaid,
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/marking,
 /area/barren/cave/central)
@@ -1871,10 +1850,6 @@
 /mob/living/simple_animal/hostile/construct/builder,
 /turf/open/lavaland/basalt,
 /area/barren/misc/clocknuke)
-"iU" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/marking,
-/area/barren/cave/central)
 "iV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/freezer,
@@ -2007,10 +1982,6 @@
 "jH" = (
 /turf/closed/wall,
 /area/barren/medical)
-"jI" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/lavaland/basalt,
-/area/barren/cave/central)
 "jJ" = (
 /obj/structure/shuttle/engine/propulsion/burst/right,
 /turf/open/floor/podhatch/floor,
@@ -2089,11 +2060,6 @@
 /mob/living/simple_animal/hostile/construct/wraith,
 /turf/open/lavaland/basalt,
 /area/barren/misc/clocknuke)
-"kb" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/south)
 "kc" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2403,12 +2369,6 @@
 /obj/item/paper/xenoresearch2,
 /turf/open/floor/mainship/sterile/dark,
 /area/barren/misc/alienstorage)
-"ls" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/bar{
-	name = "medical"
-	},
-/area/barren/medical)
 "lt" = (
 /obj/structure/barricade/guardrail,
 /turf/open/lavaland/basalt/glowing,
@@ -2896,7 +2856,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/structure/barricade/guardrail{
 	dir = 8
 	},
@@ -3496,11 +3455,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/outside/general_offices)
-"qP" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/obj/structure/cable,
-/turf/open/floor/prison/sterilewhite,
-/area/barren/medical/research)
 "qS" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
@@ -3580,11 +3534,6 @@
 	dir = 5
 	},
 /area/barren/security)
-"rj" = (
-/obj/item/tool/pickaxe,
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southwest)
 "rm" = (
 /obj/structure/closet/secure_closet/medical1/colony,
 /obj/effect/decal/cleanable/cobweb{
@@ -3611,10 +3560,6 @@
 /obj/structure/barricade/guardrail,
 /turf/open/lavaland/basalt/glowing,
 /area/barren/cave/north)
-"rs" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southwest)
 "rt" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/technology_scanner,
@@ -3634,12 +3579,6 @@
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/closed/wall,
 /area/barren/security)
-"ry" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/bar{
-	name = "medical"
-	},
-/area/barren/medical)
 "rA" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access,
 /turf/open/floor/tile/red,
@@ -3830,7 +3769,6 @@
 /area/barren/misc/clocknuke)
 "sG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/wood,
 /area/barren/security)
@@ -3870,12 +3808,6 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
-"sP" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/blue/whitebluecorner{
-	dir = 1
-	},
-/area/barren/medical)
 "sQ" = (
 /obj/item/trash/pistachios,
 /turf/open/floor/wood,
@@ -4140,11 +4072,6 @@
 	},
 /turf/closed/brock,
 /area/barren/cave/northeast)
-"ua" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/west)
 "ub" = (
 /obj/item/tool/pickaxe,
 /turf/open/lavaland/basalt,
@@ -4423,11 +4350,6 @@
 /obj/structure/sign/poster,
 /turf/closed/wall/indestructible,
 /area/barren/misc/clocknuke)
-"vC" = (
-/obj/effect/landmark/corpsespawner/miner,
-/obj/effect/decal/cleanable/blood,
-/turf/open/lavaland/basalt,
-/area/barren/cave/south)
 "vE" = (
 /obj/structure/table/reinforced,
 /turf/open/shuttle/blackfloor,
@@ -4451,7 +4373,6 @@
 "vK" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/miner/rig,
 /turf/open/floor/wood,
 /area/barren/civilian)
 "vL" = (
@@ -4841,10 +4762,6 @@
 	dir = 4
 	},
 /area/barren)
-"xU" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/northeast)
 "xV" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	name = "Cell"
@@ -5301,10 +5218,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroidfloor,
 /area/barren/cave/lz1)
-"Az" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/west)
 "AB" = (
 /obj/structure/fence,
 /turf/open/lavaland/basalt,
@@ -5433,11 +5346,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/dark,
 /area/barren/cave/lz2)
-"Bo" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/north)
 "Bq" = (
 /obj/structure/table,
 /obj/item/tool/kitchen/utensil/fork,
@@ -5731,10 +5639,6 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/tile/dark2,
 /area/barren/civilian)
-"CG" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/wood,
-/area/barren/civilian/cook)
 "CI" = (
 /turf/open/floor/tile/damaged/panel,
 /area/shuttle/drop2/lz2)
@@ -6418,11 +6322,6 @@
 /obj/structure/cable,
 /turf/open/lavaland/basalt,
 /area/barren/cave/west)
-"Gr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor,
-/area/barren/civilian)
 "Gs" = (
 /turf/open/lavaland/lava/lpiece,
 /area/barren)
@@ -6617,11 +6516,6 @@
 /obj/item/clothing/head/collectable/petehat,
 /turf/open/floor,
 /area/storage/testroom)
-"HD" = (
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/mainship,
-/area/barren/misc/crashed)
 "HE" = (
 /obj/structure/barricade/guardrail,
 /obj/structure/barricade/guardrail{
@@ -6812,7 +6706,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 8
 	},
@@ -7052,11 +6945,6 @@
 /turf/open/floor/plating,
 /turf/open/floor/plating/dmg2,
 /area/barren/cave/central)
-"JP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/floor/wood,
-/area/barren/civilian/cook)
 "JQ" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -7109,7 +6997,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark2,
@@ -7268,10 +7155,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/lavaland/basalt,
 /area/barren/cave/south)
-"Lc" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/north)
 "Le" = (
 /turf/closed/wall/mainship,
 /area/barren/cave/south)
@@ -7330,7 +7213,6 @@
 /area/barren/medical/research)
 "Lv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/bright_clean/two,
 /area/barren/security)
@@ -7397,7 +7279,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/corpsespawner/pmc,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
@@ -7560,10 +7441,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dmg3,
 /area/barren/cave/central)
-"MV" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/lavaland/basalt,
-/area/barren/cave/central)
 "MW" = (
 /obj/structure/sign/poster,
 /turf/closed/brock,
@@ -7705,7 +7582,6 @@
 /area/barren/civilian/cook)
 "NE" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/miner/rig,
 /turf/open/floor/grimy,
 /area/barren/civilian/workdorm)
 "NF" = (
@@ -8338,11 +8214,6 @@
 /obj/structure/cable,
 /turf/open/lavaland/basalt,
 /area/barren/cave/south)
-"Rr" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/mainship/sterile/dark,
-/area/barren/misc/alienstorage)
 "Rs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8548,7 +8419,6 @@
 /area/bigredv2/outside/general_offices)
 "SE" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/prison/kitchen,
 /area/barren/civilian/cook)
 "SH" = (
@@ -8859,12 +8729,6 @@
 "UD" = (
 /turf/open/floor/tile/dark2,
 /area/barren/civilian)
-"UE" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/vault,
-/area/barren/civilian)
 "UF" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/blue/whiteblue,
@@ -9057,14 +8921,6 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/prison/laundry)
-"VI" = (
-/obj/structure/bed/chair/dropship/pilot{
-	dir = 1
-	},
-/obj/effect/decal/remains/human,
-/obj/effect/landmark/corpsespawner/commander,
-/turf/open/floor/plating/mainship,
-/area/barren/misc/crashed)
 "VL" = (
 /turf/open/floor/plating/warning,
 /area/barren/cave/lz1)
@@ -9425,7 +9281,6 @@
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/wood,
 /area/barren/civilian/workdorm)
 "Yc" = (
@@ -17100,7 +16955,7 @@ ZN
 ZN
 ZN
 ZN
-Az
+ZN
 ZW
 ZW
 ZN
@@ -19168,7 +19023,7 @@ ZN
 HQ
 HQ
 HQ
-rs
+Vz
 Lh
 Cj
 HQ
@@ -20885,7 +20740,7 @@ tI
 VN
 av
 CW
-cQ
+CW
 jQ
 rq
 Bi
@@ -22242,7 +22097,7 @@ ZN
 ZN
 ZN
 ZN
-ua
+Lj
 ZN
 AE
 ZN
@@ -25372,7 +25227,7 @@ HQ
 Vz
 jh
 Lh
-rj
+ub
 HQ
 HQ
 HQ
@@ -27843,7 +27698,7 @@ aZ
 aZ
 aZ
 aZ
-Bo
+bL
 aZ
 aZ
 aZ
@@ -28452,7 +28307,7 @@ hj
 yv
 BG
 BG
-Rr
+fp
 uj
 uj
 ZK
@@ -29203,7 +29058,7 @@ jm
 dK
 dK
 WB
-qP
+jK
 dK
 dK
 YZ
@@ -31260,7 +31115,7 @@ YZ
 kN
 kN
 WW
-gD
+wm
 dK
 Lu
 YZ
@@ -31954,7 +31809,7 @@ yC
 nV
 kK
 Aj
-JP
+Ww
 qI
 rX
 om
@@ -32029,7 +31884,7 @@ Yy
 ZK
 ZK
 ZK
-vC
+oC
 Yy
 jP
 Yy
@@ -32500,7 +32355,7 @@ ZW
 fw
 fE
 hw
-bE
+mI
 bJ
 bJ
 mI
@@ -33213,7 +33068,7 @@ aZ
 aZ
 aZ
 bL
-Lc
+aZ
 aZ
 aZ
 BX
@@ -33490,7 +33345,7 @@ yw
 yw
 yw
 yw
-CG
+Aj
 Ej
 wy
 Ww
@@ -34859,7 +34714,7 @@ Yy
 Yy
 Yy
 Yy
-kb
+oC
 Yy
 Yy
 Yy
@@ -35037,7 +34892,7 @@ Cf
 Cf
 yd
 yd
-UE
+zb
 dX
 fu
 hH
@@ -36374,7 +36229,7 @@ GO
 qo
 NT
 qo
-iU
+qo
 MJ
 HA
 Qb
@@ -36602,7 +36457,7 @@ Qb
 Qb
 Eu
 Qb
-MV
+Qb
 Qb
 Qb
 Qb
@@ -37663,7 +37518,7 @@ qo
 qo
 wl
 xa
-jI
+Qb
 jx
 Qb
 Qb
@@ -37860,7 +37715,7 @@ yw
 yw
 yw
 eX
-Gr
+Dj
 Dj
 eX
 eX
@@ -38141,7 +37996,7 @@ Ew
 DU
 ki
 jH
-sP
+ZT
 MY
 BO
 jH
@@ -39499,7 +39354,7 @@ ZK
 ZK
 qM
 Vq
-VI
+cH
 FX
 Xc
 Dz
@@ -39759,7 +39614,7 @@ Dh
 cn
 Ht
 uW
-HD
+Ht
 Ht
 Ht
 Ht
@@ -39941,14 +39796,14 @@ VQ
 qb
 Gm
 MY
-ls
+DF
 DF
 DF
 DF
 DF
 oK
 MY
-ry
+DF
 DF
 DF
 DF
@@ -40027,7 +39882,7 @@ Xc
 Yy
 Yy
 Yy
-fZ
+oC
 Yy
 Yy
 ZK
@@ -42490,7 +42345,7 @@ OD
 OD
 OD
 OD
-xU
+OD
 DW
 DW
 OD

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -21079,10 +21079,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/north)
-"qqG" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/southwest)
 "qtI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -21183,10 +21179,6 @@
 /obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
-"qRX" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/north)
 "qUm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21378,10 +21370,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
-"sQi" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/south)
 "sUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21449,10 +21437,6 @@
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
-"ttW" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave/rock,
-/area/bigredv2/caves/east)
 "ttZ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
@@ -21718,10 +21702,6 @@
 "vwf" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/space_port)
-"vyZ" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/northeast)
 "vAP" = (
 /obj/docking_port/stationary/crashmode,
 /obj/structure/cable,
@@ -21798,10 +21778,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
-"whf" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/east)
 "wmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -25927,7 +25903,7 @@ tvk
 tvk
 liu
 dSm
-qqG
+puQ
 puQ
 puQ
 puQ
@@ -39840,7 +39816,7 @@ hqP
 hqP
 dGX
 xEN
-sQi
+xEN
 xEN
 xEN
 xEN
@@ -50324,7 +50300,7 @@ xpB
 xpB
 xpB
 uLz
-qRX
+xpB
 xpB
 abq
 qVr
@@ -51546,7 +51522,7 @@ xEN
 iyn
 xWD
 xEN
-sQi
+xEN
 xEN
 xEN
 xEN
@@ -56284,7 +56260,7 @@ tzo
 tzo
 kPf
 tzo
-whf
+tzo
 tzo
 yfA
 tzo
@@ -60416,7 +60392,7 @@ tzo
 tzo
 tzo
 tzo
-ttW
+uMP
 oOR
 uMP
 uMP
@@ -62810,7 +62786,7 @@ oOR
 oOR
 oOR
 tzo
-whf
+tzo
 eve
 eve
 eve
@@ -67314,7 +67290,7 @@ adZ
 ptP
 dnl
 vCh
-whf
+tzo
 tzo
 tzo
 xJh
@@ -67502,7 +67478,7 @@ uLR
 vCh
 vCh
 vCh
-vyZ
+vCh
 vCh
 dnl
 dnl
@@ -67540,7 +67516,7 @@ tzo
 tzo
 tzo
 uMP
-whf
+tzo
 oOR
 oOR
 oOR
@@ -67692,7 +67668,7 @@ vCh
 kKe
 vCh
 vCh
-vyZ
+vCh
 vCh
 dnl
 dnl

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -720,10 +720,6 @@
 	},
 /turf/open/floor/elevatorshaft,
 /area/bigredv2/caves/lambda_lab)
-"acL" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "acM" = (
 /obj/structure/table,
 /turf/open/floor/tile/white,
@@ -856,7 +852,6 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/marshal_office)
 "ado" = (
@@ -968,12 +963,6 @@
 "adG" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/landmark/corpsespawner/security{
-	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
-	corpsesuit = /obj/item/clothing/suit/storage/CMB;
-	corpseuniform = /obj/item/clothing/under/CM_uniform;
-	name = "Marshal Logan Bills"
-	},
 /obj/structure/window_frame/colony/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/marshal_office)
@@ -3322,7 +3311,6 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "amp" = (
@@ -3844,7 +3832,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aob" = (
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/green/whitegreen{
 	dir = 8
 	},
@@ -6691,7 +6678,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "ayh" = (
@@ -6816,7 +6802,6 @@
 "ayP" = (
 /obj/item/weapon/broken_bottle,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "ayQ" = (
@@ -6974,7 +6959,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "azv" = (
@@ -7790,7 +7774,6 @@
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
 "aCq" = (
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/engine,
 /area/bigredv2/caves/lambda_lab)
@@ -8428,19 +8411,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/tile/green/whitegreenfull,
-/area/bigredv2/outside/medical)
-"aEH" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpseidjob = "Doctor";
-	name = "Colonist Ted Koso"
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "aEI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9731,7 +9701,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/freezer,
 /area/bigredv2/outside/hydroponics)
 "aJx" = (
@@ -9998,7 +9967,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner{
 	dir = 8
 	},
@@ -10946,7 +10914,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "aOB" = (
@@ -11565,7 +11532,6 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aSp" = (
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 9
 	},
@@ -12081,7 +12047,6 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aUF" = (
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner{
 	dir = 8
 	},
@@ -14754,13 +14719,6 @@
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
-"biK" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Ethan Peser"
-	},
-/turf/open/floor,
-/area/bigredv2/outside/cargo)
 "biL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/megaphone,
@@ -15610,13 +15568,6 @@
 /area/bigredv2/outside/engineering)
 "bmX" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpsehelmet = /obj/item/clothing/head/welding;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Ted Jarka"
-	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "bmY" = (
@@ -16086,16 +16037,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"bpm" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpsehelmet = /obj/item/clothing/head/welding;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Ted Jarka"
-	},
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
 "bpn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -16240,7 +16181,6 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "bpT" = (
@@ -17655,11 +17595,6 @@
 	dir = 6
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"byt" = (
-/obj/structure/bed,
-/obj/effect/landmark/corpsespawner/PMC,
-/turf/open/floor/wood,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "byv" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -18498,7 +18433,6 @@
 "bBW" = (
 /obj/item/tool/pen,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bBX" = (
@@ -19280,10 +19214,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
-"bQk" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/yellow/full,
-/area/bigredv2/outside/hydroponics)
 "bSC" = (
 /obj/machinery/light{
 	dir = 8
@@ -19320,10 +19250,6 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
-"cgP" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor,
-/area/bigredv2/outside/general_store)
 "chz" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/wood,
@@ -19434,10 +19360,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
-"djI" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/wood,
-/area/bigredv2/caves/lambda_lab)
 "djN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -19484,10 +19406,6 @@
 	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/virology)
-"dwi" = (
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/general_offices)
 "dzS" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
@@ -19564,10 +19482,6 @@
 /turf/open/floor/tile/dark/yellow2/corner{
 	dir = 8
 	},
-/area/bigredv2/outside/nanotrasen_lab/inside)
-"dZF" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "eal" = (
 /obj/structure/table,
@@ -19725,10 +19639,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
-"flV" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
 "fmD" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -19964,13 +19874,6 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"gSH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/green/whitegreen{
-	dir = 4
-	},
-/area/bigredv2/outside/medical)
 "gTX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -20083,11 +19986,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
-"hJM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
 "hKr" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -20110,13 +20008,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
-"hUm" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor,
-/area/bigredv2/outside/general_offices)
 "hVb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -20135,10 +20026,6 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/wood,
-/area/bigredv2/outside/nanotrasen_lab/inside)
-"ilD" = (
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "iug" = (
@@ -20171,10 +20058,6 @@
 /obj/machinery/light,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
-"iMZ" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/red/redtaupecorner,
-/area/bigredv2/outside/office_complex)
 "iNt" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -20374,12 +20257,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/virology)
-"kAp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor,
-/area/bigredv2/outside/general_store)
 "kCz" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -20403,10 +20280,6 @@
 "kKe" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northeast)
-"kMq" = (
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/tile/white,
-/area/bigredv2/outside/virology)
 "kNX" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20444,10 +20317,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/southwest)
-"liQ" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab)
 "lji" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20456,10 +20325,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
-"ljS" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
 "loj" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/engine/cult,
@@ -20573,15 +20438,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
-"mgD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor,
-/area/bigredv2/outside/marshal_office)
 "mlt" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/north)
@@ -20599,11 +20455,6 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"mxH" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/carpet,
-/area/bigredv2/outside/library)
 "mAi" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northwest)
@@ -20716,10 +20567,6 @@
 	dir = 6
 	},
 /area/bigredv2/outside/se)
-"nAe" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/white,
-/area/bigredv2/outside/medical)
 "nFd" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -20937,32 +20784,16 @@
 	dir = 5
 	},
 /area/bigredv2/outside/space_port)
-"pfi" = (
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab)
 "pjz" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
 	},
 /area/shuttle/drop2/lz2)
-"pmf" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/tile/white,
-/area/bigredv2/outside/medical)
 "pmR" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/elevatorshaft,
 /area/bigredv2/caves/lambda_lab)
-"pod" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "poJ" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/asteroidfloor,
@@ -21085,10 +20916,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/medical)
-"qvi" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/white,
-/area/bigredv2/outside/virology)
 "qvO" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -21149,11 +20976,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/nw)
-"qIi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "qIY" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -21168,17 +20990,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/virology)
-"qQd" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark/purple2/corner{
-	dir = 4
-	},
-/area/bigredv2/caves/lambda_lab)
-"qRs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/chef,
-/turf/open/floor/grimy,
-/area/bigredv2/outside/dorms)
 "qUm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21213,10 +21024,6 @@
 /obj/item/trash/tray,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
-"rfg" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor,
-/area/bigredv2/outside/cargo)
 "riz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -21226,10 +21033,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
-"rnW" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark/yellow2/corner,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "rpV" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
@@ -21496,14 +21299,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
-"tKU" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/white,
-/area/bigredv2/caves/lambda_lab)
-"tNb" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/plating,
-/area/bigredv2/caves/lambda_lab)
 "tVO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -21554,11 +21349,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
-"uhF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor,
-/area/bigredv2/outside/marshal_office)
 "uja" = (
 /obj/structure/window/framed/colony/reinforced/hull,
 /obj/docking_port/stationary/crashmode,
@@ -21584,11 +21374,6 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
-"uqm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/green/whitegreencorner,
-/area/bigredv2/outside/medical)
 "utl" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
@@ -21663,11 +21448,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/s)
-"uXL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor,
-/area/bigredv2/outside/filtration_plant)
 "vbs" = (
 /obj/structure/sign/safety/hazard,
 /turf/open/floor/marking/asteroidwarning,
@@ -21732,12 +21512,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/south)
-"vMd" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor,
-/area/bigredv2/outside/dorms)
 "vNk" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -21937,10 +21711,6 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
-"xAO" = (
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor,
-/area/bigredv2/outside/general_offices)
 "xCx" = (
 /turf/open/space/basic,
 /area/bigredv2/outside/admin_building)
@@ -21963,13 +21733,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
-"xIT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark/blue2{
-	dir = 8
-	},
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "xJh" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22017,10 +21780,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
-"xWK" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/darkgreen/darkgreen2,
-/area/bigredv2/caves/lambda_lab)
 "xYz" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -27790,7 +27549,7 @@ aNc
 aRJ
 aSy
 aNc
-qvi
+aNc
 aNc
 aWi
 aNc
@@ -28011,7 +27770,7 @@ aNc
 aNc
 aWi
 aNc
-kMq
+aNc
 aNc
 aNc
 aNc
@@ -32345,7 +32104,7 @@ gnu
 ouJ
 ouJ
 aQM
-kAp
+ouJ
 ouJ
 aQM
 ouJ
@@ -33427,7 +33186,7 @@ aMa
 aMD
 aNm
 aOy
-cgP
+aNo
 aNo
 aNo
 aNo
@@ -33674,7 +33433,7 @@ bgD
 bbe
 bhE
 bin
-biK
+blb
 aZO
 aZO
 aZN
@@ -33877,7 +33636,7 @@ aZo
 blb
 aZO
 biq
-rfg
+blb
 hcr
 aZO
 bdL
@@ -34539,7 +34298,7 @@ blb
 blb
 blb
 blb
-rfg
+blb
 uTl
 bip
 blb
@@ -35831,7 +35590,7 @@ blb
 aZO
 bir
 blb
-rfg
+blb
 aZN
 aZO
 beg
@@ -36237,7 +35996,7 @@ aBJ
 aCB
 aod
 axB
-gSH
+axB
 avy
 aHt
 apC
@@ -36658,7 +36417,7 @@ aqw
 aqw
 aqz
 auL
-nAe
+aqw
 awe
 awP
 apC
@@ -37288,7 +37047,7 @@ aeL
 aeL
 acp
 agB
-uhF
+adk
 aic
 acp
 aiY
@@ -37539,7 +37298,7 @@ aBO
 awN
 aDJ
 aDJ
-uqm
+aDJ
 awN
 aHx
 apC
@@ -37590,7 +37349,7 @@ aBR
 hEq
 bmo
 ekm
-hJM
+bmg
 bmg
 bmg
 bmg
@@ -38262,7 +38021,7 @@ btz
 bmm
 buD
 bvh
-flV
+buD
 buD
 btz
 btz
@@ -38403,7 +38162,7 @@ ayO
 azA
 arR
 aqw
-nAe
+aqw
 aqw
 aDL
 aqw
@@ -38611,7 +38370,7 @@ arY
 arY
 atW
 atr
-pmf
+atr
 arU
 arR
 aqw
@@ -38696,7 +38455,7 @@ btz
 buD
 mbT
 btZ
-ljS
+buD
 buD
 btz
 btz
@@ -39113,7 +38872,7 @@ bom
 bom
 ekm
 boT
-bpm
+bmi
 bor
 bsM
 bmk
@@ -39127,7 +38886,7 @@ blJ
 btz
 btz
 btz
-ljS
+buD
 btz
 bvj
 btz
@@ -39249,7 +39008,7 @@ ajE
 ajE
 akP
 alq
-mgD
+amh
 aic
 anx
 afS
@@ -39708,7 +39467,7 @@ awO
 aqz
 aCK
 aDO
-aEH
+arT
 aFI
 aGD
 aqz
@@ -43304,7 +43063,7 @@ bxo
 bxo
 bxg
 bxo
-dZF
+bxg
 bxg
 qvO
 xEN
@@ -43490,7 +43249,7 @@ acd
 bxF
 bxF
 bxF
-xIT
+bxv
 byz
 byJ
 bwF
@@ -43828,7 +43587,7 @@ asJ
 azQ
 aAC
 aAC
-vMd
+atA
 atA
 aAC
 aAC
@@ -44350,7 +44109,7 @@ bjw
 bwF
 abW
 bxc
-acL
+bxc
 bAg
 bwF
 bwS
@@ -45013,7 +44772,7 @@ bxY
 bxY
 bxY
 bza
-dZF
+bxg
 byM
 bzT
 bzT
@@ -45241,7 +45000,7 @@ bzb
 bzb
 bBE
 bxn
-pod
+bBU
 bBU
 bBU
 bCB
@@ -45627,7 +45386,7 @@ bpq
 bnG
 bnG
 bkE
-uXL
+bkQ
 bly
 bsG
 asV
@@ -46210,7 +45969,7 @@ asJ
 awq
 axM
 axM
-qRs
+axM
 axM
 azR
 asH
@@ -46310,7 +46069,7 @@ bxo
 bxo
 bxg
 bxP
-qIi
+bxo
 bAW
 bwJ
 byT
@@ -46783,7 +46542,7 @@ bEy
 bxS
 bxN
 bEK
-rnW
+bCZ
 bwF
 vKO
 hqP
@@ -46996,7 +46755,7 @@ bDY
 bxN
 bEl
 bxS
-ilD
+bxS
 bxR
 bxN
 bEK
@@ -47396,7 +47155,7 @@ vKO
 bwF
 bxR
 bxS
-byt
+bxR
 bxN
 byT
 bzf
@@ -48430,7 +48189,7 @@ bbB
 bbB
 bbB
 bcj
-iMZ
+bbB
 bbB
 bbB
 bbB
@@ -48811,7 +48570,7 @@ atE
 apc
 anI
 atE
-hUm
+aop
 apc
 axR
 ayw
@@ -51651,7 +51410,7 @@ aIz
 wmv
 aIC
 aLA
-bQk
+aIE
 aCZ
 aIE
 aCZ
@@ -51845,7 +51604,7 @@ aoB
 ary
 asj
 aoB
-dwi
+aoB
 aoB
 asj
 atE
@@ -52934,7 +52693,7 @@ apU
 aoB
 anK
 atE
-xAO
+apc
 apc
 anI
 avL
@@ -55119,7 +54878,7 @@ aDe
 pZW
 aGO
 aGO
-mxH
+aGO
 aGO
 aGO
 aGO
@@ -59216,7 +58975,7 @@ afz
 amI
 afz
 afz
-tNb
+afz
 afy
 adZ
 adZ
@@ -60307,7 +60066,7 @@ aqc
 aqc
 aqc
 asp
-djI
+aqc
 adZ
 agc
 acS
@@ -62244,7 +62003,7 @@ dnl
 dnl
 adZ
 adZ
-qQd
+ahL
 aiS
 ajp
 ajV
@@ -62694,7 +62453,7 @@ afv
 efK
 adZ
 asw
-liQ
+agd
 agj
 avk
 avk
@@ -64664,7 +64423,7 @@ aDq
 agj
 agd
 agc
-pfi
+agc
 aGX
 aHR
 agQ
@@ -64850,7 +64609,7 @@ agk
 agk
 ait
 aiV
-tKU
+agl
 adZ
 ptP
 dnl
@@ -67501,7 +67260,7 @@ aRB
 aSr
 aTG
 wfD
-xWK
+aVz
 aWb
 adZ
 ptP

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -1456,17 +1456,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseglasses = /obj/item/clothing/glasses/welding;
-	corpsemask = /obj/item/clothing/mask/rebreather;
-	corpsepocket1 = /obj/item/storage/pouch/general/medium;
-	corpsepocket2 = /obj/item/storage/pouch/electronics/full;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/engineer;
-	name = "Engi"
-	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering)
@@ -2933,7 +2922,6 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_e)
@@ -4002,7 +3990,6 @@
 /area/ice_colony/surface/mining)
 "apN" = (
 /obj/machinery/optable,
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/tile/red/whitered,
@@ -4016,10 +4003,6 @@
 "apP" = (
 /obj/item/stack/sheet/metal{
 	amount = 10
-	},
-/obj/effect/landmark/corpsespawner/engineer{
-	pixel_x = 2;
-	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark2,
@@ -4280,7 +4263,6 @@
 /area/ice_colony/surface/clinic/treatment)
 "aqD" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/ice_colony/surface/clinic/treatment)
@@ -5177,15 +5159,6 @@
 	},
 /area/ice_colony/surface/clinic/lobby)
 "atB" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpsebelt = /obj/item/storage/belt/medical;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpsepocket2 = /obj/item/storage/pouch/medkit/full;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit/doctor;
-	name = "Dr. Micheal Hwang"
-	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/white,
 /area/ice_colony/surface/clinic/lobby)
@@ -5465,7 +5438,6 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/ice_colony/exterior/surface/valley/southeast)
 "aut" = (
-/obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/ice_colony/surface/dorms)
@@ -10238,9 +10210,6 @@
 	},
 /area/ice_colony/exterior/surface/valley/southwest)
 "aJJ" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer{
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit
-	},
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
@@ -10795,20 +10764,6 @@
 /obj/effect/turf_underlay/icefloor,
 /turf/closed/ice/thin/straight,
 /area/ice_colony/exterior/surface/clearing/south)
-"aLR" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ice_colony/surface/mining)
 "aLT" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15802,9 +15757,6 @@
 "bbH" = (
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/bridgeofficer{
-	corpsegloves = /obj/item/clothing/gloves/black
-	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/command/crisis)
 "bbI" = (
@@ -16120,15 +16072,6 @@
 /area/ice_colony/surface/excavationbarracks)
 "bcT" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/doctor{
-	corpsebelt = /obj/item/storage/belt/medical;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpsepocket2 = /obj/item/storage/pouch/medkit/full;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit/doctor;
-	name = "Colonist Doctor"
-	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/command/crisis)
 "bcU" = (
@@ -16712,17 +16655,6 @@
 /area/ice_colony/exterior/surface/clearing/south)
 "beS" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseglasses = /obj/item/clothing/glasses/welding;
-	corpsemask = /obj/item/clothing/mask/rebreather;
-	corpsepocket1 = /obj/item/storage/pouch/general/medium;
-	corpsepocket2 = /obj/item/storage/pouch/electronics/full;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/engineer;
-	name = "Engi"
-	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/exterior/surface/clearing/south)
 "beT" = (
@@ -21096,7 +21028,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/hallway/north_west)
@@ -26284,7 +26215,6 @@
 /area/ice_colony/underground/security/brig)
 "bKN" = (
 /obj/structure/bed,
-/obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 5
@@ -26352,10 +26282,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
-	},
-/obj/effect/landmark/corpsespawner/miner{
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/surface/bar/bar)
@@ -26805,7 +26731,6 @@
 /area/ice_colony/underground/hallway/south_east)
 "bMG" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/south_east)
 "bMH" = (
@@ -28711,17 +28636,6 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/east)
 "bTa" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseglasses = /obj/item/clothing/glasses/welding;
-	corpsemask = /obj/item/clothing/mask/rebreather;
-	corpsepocket1 = /obj/item/storage/pouch/general/medium;
-	corpsepocket2 = /obj/item/storage/pouch/electronics/full;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/engineer;
-	name = "Engi"
-	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/ice_colony/underground/engineering/substation)
@@ -29183,7 +29097,6 @@
 /area/ice_colony/underground/command/checkpoint)
 "bUT" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/armory)
 "bUU" = (
@@ -30105,10 +30018,6 @@
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/dark,
 /area/ice_colony/surface/excavationbarracks)
-"bXY" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/ice_colony/exterior/surface/valley/south/excavation)
 "bXZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/item/storage/box/lightstick{
@@ -30153,13 +30062,6 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/valley/south/excavation)
 "bYh" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpsehelmet = /obj/item/clothing/head/hardhat;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood,
@@ -30930,11 +30832,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ice_colony/underground/engineering/substation)
-"caP" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating,
-/area/ice_colony/exterior/underground/caves/open)
 "cbO" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/weed_node,
@@ -30999,7 +30896,6 @@
 /area/ice_colony/underground/hallway/north_west)
 "ccA" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark/blue2,
 /area/ice_colony/underground/command/center)
 "ccB" = (
@@ -31130,17 +31026,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseglasses = /obj/item/clothing/glasses/welding;
-	corpsemask = /obj/item/clothing/mask/rebreather;
-	corpsepocket1 = /obj/item/storage/pouch/general/medium;
-	corpsepocket2 = /obj/item/storage/pouch/electronics/full;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/engineer;
-	name = "Engi"
-	},
 /turf/open/floor/carpet,
 /area/ice_colony/underground/crew/leisure)
 "cdW" = (
@@ -39836,7 +39721,7 @@ bmU
 bmU
 bbq
 bbq
-caP
+cda
 bbq
 bbq
 hAN
@@ -59574,7 +59459,7 @@ bcL
 bci
 bci
 bbK
-bXY
+bbK
 bbK
 dyb
 btz
@@ -82083,7 +81968,7 @@ alE
 amj
 amK
 amK
-aLR
+amK
 aoq
 aoY
 amk

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -31200,10 +31200,6 @@
 	dir = 1
 	},
 /area/ice_colony/exterior/underground/caves/ice_w)
-"cup" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/ice_colony/underground/maintenance/east)
 "cvo" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/tile/dark/brown2{
@@ -31473,20 +31469,12 @@
 "fgG" = (
 /turf/closed/ice_rock/eastWall,
 /area/ice_colony/exterior/surface/landing_pad2)
-"fiX" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/ice_colony/exterior/underground/caves/open)
 "fjG" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice/straight{
 	dir = 4
 	},
 /area/ice_colony/exterior/underground/caves)
-"fnv" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/ice_colony/underground/maintenance/south)
 "fol" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -31604,10 +31592,6 @@
 	dir = 4
 	},
 /area/ice_colony/exterior/underground/caves/open)
-"gid" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/ice_colony/exterior/underground/caves)
 "gjB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
@@ -32547,10 +32531,6 @@
 	dir = 5
 	},
 /area/ice_colony/exterior/surface/cliff)
-"nWj" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/ice_colony/exterior/underground/caves/ice_se)
 "nXf" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/tile/dark/brown2{
@@ -32859,10 +32839,6 @@
 "qCb" = (
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/underground/caves/ice_nw)
-"qCE" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/ice_colony/underground/maintenance/engineering)
 "qDA" = (
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/landing_pad2)
@@ -32873,10 +32849,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/underground/maintenance/east)
-"qGt" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/ice_colony/underground/maintenance/central)
 "qIx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -37994,7 +37966,7 @@ aac
 aaC
 bmU
 bmU
-fiX
+bmU
 boD
 bmU
 bmU
@@ -38576,7 +38548,7 @@ bGw
 bGw
 bwK
 bwK
-gid
+bwK
 bwK
 jyH
 bmU
@@ -51671,7 +51643,7 @@ oTc
 bSb
 bSb
 bSb
-qGt
+rxl
 bSb
 bSb
 bSb
@@ -52981,7 +52953,7 @@ bqx
 boJ
 tit
 bQu
-fnv
+bQu
 bQu
 bQu
 bQu
@@ -64261,7 +64233,7 @@ byc
 bqP
 byc
 bRV
-qCE
+byc
 bmk
 bmQ
 aZF
@@ -64787,7 +64759,7 @@ nKI
 bpj
 bBQ
 bUp
-cup
+bFH
 bFH
 bFH
 bEx
@@ -69107,7 +69079,7 @@ aac
 aae
 tKg
 bPX
-nWj
+tKg
 bPX
 tKg
 tKg
@@ -72990,7 +72962,7 @@ aZF
 bmU
 bmU
 bmU
-fiX
+bmU
 bmU
 bmU
 bmU
@@ -73282,7 +73254,7 @@ bmU
 bmU
 bmU
 bmU
-fiX
+bmU
 bmU
 boD
 bmU

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -286,10 +286,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west2)
-"acH" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "acI" = (
 /turf/closed/mineral,
 /area/lv624/ground/sand6)
@@ -2264,17 +2260,6 @@
 	},
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
-"amS" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Tevin Marks"
-	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/lazarus/research)
 "amT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -4062,11 +4047,6 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/item/clothing/mask/facehugger/dead,
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Jan Horris"
-	},
 /turf/open/floor/freezer,
 /area/lv624/lazarus/research)
 "awJ" = (
@@ -12846,10 +12826,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship/two,
 /turf/open/ground/grass,
 /area/lv624/lazarus/console)
-"cKI" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "cKV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13290,7 +13266,6 @@
 /turf/open/floor,
 /area/lv624/ground/jungle4)
 "eBP" = (
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating/warning{
 	dir = 4
 	},
@@ -14190,14 +14165,6 @@
 /obj/structure/jungle/vines,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle6)
-"izp" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river1)
-"iCK" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle9)
 "iEQ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/marking/bot,
@@ -14353,10 +14320,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
-"jqG" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/blue/whitebluecorner,
-/area/lv624/lazarus/medbay)
 "jqR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14989,11 +14952,6 @@
 /turf/open/floor/engine/cult,
 /area/lv624/ground/caves/west1)
 "mre" = (
-/obj/effect/landmark/corpsespawner/chef{
-	corpsesuit = null;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Jed Willis"
-	},
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/item/weapon/harpoon,
 /turf/open/floor/plating/ground/dirt,
@@ -15055,12 +15013,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle4)
-"mAI" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/green/greentaupe{
-	dir = 1
-	},
-/area/lv624/lazarus/hydroponics)
 "mAP" = (
 /obj/structure/sign/botany{
 	dir = 4
@@ -15134,10 +15086,6 @@
 /obj/structure/jungle/planttop1,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
-"mNl" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle6)
 "mNK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -16530,13 +16478,6 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage)
-"toh" = (
-/obj/machinery/light,
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/lazarus/research)
 "tqg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -20955,7 +20896,7 @@ aBM
 avL
 avO
 avL
-izp
+avL
 unC
 aug
 auk
@@ -22606,7 +22547,7 @@ bnE
 bnE
 hAe
 bnE
-cKI
+bnE
 biP
 biP
 hAe
@@ -26497,7 +26438,7 @@ aBg
 tal
 axR
 axR
-mNl
+axR
 aXH
 aXH
 aXH
@@ -28314,7 +28255,7 @@ aFB
 aJD
 aEx
 aEx
-iCK
+aEx
 aEx
 aEx
 jbc
@@ -29168,7 +29109,7 @@ auf
 avc
 avL
 avL
-mNl
+axR
 axR
 axR
 axR
@@ -30442,7 +30383,7 @@ axR
 aFo
 aFX
 juW
-amS
+aGd
 aHM
 aGd
 aJm
@@ -31325,7 +31266,7 @@ ayu
 awn
 awn
 awn
-jqG
+awn
 aBm
 awJ
 avV
@@ -31695,7 +31636,7 @@ aAb
 aFo
 inf
 aGB
-toh
+aHh
 aEN
 aeB
 aJq
@@ -32219,7 +32160,7 @@ axW
 ayx
 awn
 azE
-jqG
+awn
 awn
 aBq
 aBU
@@ -33615,7 +33556,7 @@ bnS
 boK
 bpM
 bqo
-acH
+bqo
 brB
 bjH
 bjH
@@ -34184,7 +34125,7 @@ awq
 awP
 awP
 awP
-mAI
+awa
 awa
 awa
 awR
@@ -35618,7 +35559,7 @@ awR
 awR
 awa
 awa
-mAI
+awa
 awP
 awP
 awP

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -12669,10 +12669,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/lv624/ground/river2)
-"bQV" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/east1)
 "bRK" = (
 /turf/open/ground/coast/corner2{
 	dir = 4
@@ -13800,11 +13796,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/sand1)
-"gyP" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/central3)
 "gzj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -16741,10 +16732,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
-"ujY" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/west1)
 "unj" = (
 /obj/effect/spawner/modularmap/lv624/domes,
 /turf/open/space/basic,
@@ -20166,7 +20153,7 @@ ozL
 aej
 aej
 aej
-etu
+aej
 aej
 aej
 aej
@@ -21101,7 +21088,7 @@ abb
 abb
 abb
 abc
-ujY
+abc
 abc
 udq
 udq
@@ -21966,7 +21953,7 @@ aej
 abc
 abc
 abc
-ujY
+abc
 abb
 abb
 abb
@@ -23948,7 +23935,7 @@ abd
 abc
 abc
 abd
-ujY
+abc
 abc
 abc
 abc
@@ -30557,7 +30544,7 @@ acO
 acO
 aeu
 acO
-gyP
+adh
 acO
 aeK
 acN
@@ -44180,7 +44167,7 @@ cRa
 afr
 afn
 abi
-bQV
+abi
 abo
 afg
 afg

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -543,7 +543,6 @@
 	},
 /area/magmoor/cargo/storage/south)
 "aCq" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/storage/south)
@@ -554,7 +553,6 @@
 /turf/open/floor/mainship,
 /area/magmoor/landing/two)
 "aCO" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/item/weapon/gun/revolver/cmb,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/blue/corner{
@@ -2016,7 +2014,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -2761,7 +2758,6 @@
 	},
 /area/magmoor/cave/northwest)
 "cvr" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing/south)
@@ -3031,7 +3027,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -3126,7 +3121,6 @@
 	},
 /area/magmoor/cave/northwest)
 "cFR" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/purple,
 /area/magmoor/civilian/dorms)
@@ -3640,7 +3634,6 @@
 	},
 /area/magmoor/research/decontamination)
 "cWT" = (
-/obj/effect/landmark/corpsespawner/security,
 /obj/item/shard,
 /obj/item/shard,
 /obj/item/weapon/gun/revolver/cmb,
@@ -3853,7 +3846,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/arrival)
@@ -4138,10 +4130,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/magmoor/mining)
-"dlC" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/magmoor/compound/northwest)
 "dlH" = (
 /obj/structure/window_frame/colony/reinforced,
 /obj/item/shard,
@@ -4668,7 +4656,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/landmark/corpsespawner/security,
 /obj/item/weapon/gun/energy/taser,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
@@ -5569,11 +5556,6 @@
 	dir = 1
 	},
 /area/magmoor/cave/central)
-"efq" = (
-/obj/effect/landmark/corpsespawner/security,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/carpet,
-/area/magmoor/command/conference)
 "efw" = (
 /turf/open/lavaland/basalt/cave{
 	dir = 4
@@ -6220,7 +6202,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
@@ -11008,14 +10989,6 @@
 /obj/structure/flora/rock/pile/alt2,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/northeast)
-"imG" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/corpsespawner/bridgeofficer,
-/turf/open/floor/freezer,
-/area/magmoor/civilian/clean/toilet)
 "imL" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -11799,13 +11772,6 @@
 	dir = 4
 	},
 /area/magmoor/mining/refinery)
-"iUo" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/obj/effect/landmark/corpsespawner/scientist,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/wood,
-/area/magmoor/civilian/dorms)
 "iUv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -12614,7 +12580,6 @@
 	},
 /area/magmoor/security/lobby)
 "jww" = (
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/blue/corner,
 /area/magmoor/command/commandroom)
@@ -12733,7 +12698,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/prison/kitchen,
 /area/magmoor/civilian/cook)
 "jCZ" = (
@@ -12865,7 +12829,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
@@ -13406,7 +13369,6 @@
 "kbq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
@@ -13760,13 +13722,6 @@
 	dir = 8
 	},
 /area/magmoor/compound/northeast)
-"krc" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
-/obj/effect/landmark/corpsespawner/bridgeofficer,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/wood,
-/area/magmoor/civilian/dorms)
 "krh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14068,7 +14023,6 @@
 	},
 /area/magmoor/cave/west)
 "kDG" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound)
@@ -14103,7 +14057,6 @@
 /area/magmoor/cave/east)
 "kFq" = (
 /obj/structure/flora/grass/green,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/grass,
 /area/magmoor/hydroponics)
@@ -15115,7 +15068,6 @@
 	},
 /area/magmoor/cave/west)
 "ltY" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 6
@@ -15405,7 +15357,6 @@
 	},
 /area/magmoor/cave/northeast)
 "lFi" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/red{
 	dir = 8
@@ -15681,7 +15632,6 @@
 /area/magmoor/cave/central)
 "lNw" = (
 /obj/structure/table/woodentable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
@@ -16711,7 +16661,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/plating_catwalk,
 /area/magmoor/civilian/clean/shower)
@@ -16815,7 +16764,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
@@ -16883,7 +16831,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
@@ -17497,7 +17444,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
@@ -19821,7 +19767,6 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/magmoor/compound)
 "oRJ" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/item/bananapeel,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
@@ -19932,7 +19877,6 @@
 	},
 /area/magmoor/civilian/dorms)
 "oVH" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -21084,7 +21028,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing)
@@ -21261,7 +21204,6 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing)
 "pRI" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/orange/corner,
 /area/magmoor/cargo/processing/south)
@@ -21797,7 +21739,6 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/security/infocenter)
 "qkY" = (
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/storage)
@@ -21877,7 +21818,6 @@
 /turf/open/floor/cult,
 /area/magmoor/cave/north)
 "qoh" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
@@ -22301,7 +22241,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -22779,7 +22718,6 @@
 	},
 /area/magmoor/compound/northeast)
 "qWE" = (
-/obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/mining/fossil)
@@ -23228,7 +23166,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/mainship,
 /area/magmoor/engi/storage)
@@ -23272,7 +23209,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
@@ -23462,7 +23398,6 @@
 /turf/closed/mineral,
 /area/magmoor/cave/west)
 "rwJ" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/ground/grass,
 /area/magmoor/hydroponics/south)
@@ -23608,7 +23543,6 @@
 	},
 /area/magmoor/cargo/processing)
 "rAR" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing)
@@ -24466,7 +24400,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/red{
 	dir = 4
@@ -24808,7 +24741,6 @@
 /area/magmoor/civilian/bar)
 "soc" = (
 /obj/structure/bed/roller,
-/obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark2,
 /area/magmoor/civilian/chapel)
 "sof" = (
@@ -24848,7 +24780,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -24928,7 +24859,6 @@
 /obj/structure/bed/chair/pew{
 	dir = 10
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/chapel{
 	dir = 8
@@ -24952,7 +24882,6 @@
 /turf/open/floor/carpet,
 /area/magmoor/civilian/chapel)
 "suz" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/carpet{
 	dir = 4;
@@ -25116,7 +25045,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing)
@@ -25224,7 +25152,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/chapel)
@@ -25322,7 +25249,6 @@
 /area/magmoor/medical/lobby)
 "sFE" = (
 /obj/structure/table/reinforced/prison,
-/obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark2,
 /area/magmoor/civilian/chapel)
 "sGc" = (
@@ -25478,7 +25404,6 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/northwest)
 "sNd" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound/west)
@@ -26192,7 +26117,6 @@
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/cave/southeast)
 "tlt" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/compound/north)
@@ -26619,7 +26543,6 @@
 	},
 /area/magmoor/mining)
 "tzV" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge,
 /area/magmoor/compound/north)
@@ -27377,7 +27300,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -27462,13 +27384,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/plain,
 /area/magmoor/security/infocenter)
-"ugZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/ce,
-/obj/effect/landmark/corpsespawner/clown,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/wood,
-/area/magmoor/civilian/dorms)
 "uhd" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -27500,7 +27415,6 @@
 "uhE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/ce,
-/obj/effect/landmark/corpsespawner/chef,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
@@ -27626,7 +27540,6 @@
 /turf/open/floor/plating/ground/concrete,
 /area/magmoor/compound/west)
 "umV" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
@@ -27743,7 +27656,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/lobby)
@@ -28140,7 +28052,6 @@
 /turf/open/floor/cult,
 /area/magmoor/cave/northeast)
 "uDg" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/command/office/main)
@@ -28154,19 +28065,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue/taupebluecorner{
 	dir = 4
-	},
-/area/magmoor/civilian/dorms)
-"uDY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/blue/taupeblue{
-	dir = 1
 	},
 /area/magmoor/civilian/dorms)
 "uEo" = (
@@ -28222,7 +28120,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -28364,7 +28261,6 @@
 	},
 /area/magmoor/cargo/processing)
 "uKK" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -28515,10 +28411,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/blue/taupeblue,
 /area/magmoor/civilian/dorms)
-"uRm" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/blue/taupeblue,
-/area/magmoor/civilian/dorms)
 "uRs" = (
 /obj/machinery/mining/brace/active{
 	dir = 1
@@ -28597,7 +28489,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/lobby)
@@ -28646,7 +28537,6 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean/shower)
@@ -29361,7 +29251,6 @@
 "vqm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
@@ -29600,7 +29489,6 @@
 /turf/closed/wall/indestructible/mineral,
 /area/magmoor/compound/west)
 "vzt" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
@@ -30014,7 +29902,6 @@
 /turf/open/floor/carpet,
 /area/magmoor/command/conference)
 "vPd" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/item/ammo_casing/bullet,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet,
@@ -30632,7 +30519,6 @@
 /area/magmoor/security/arrivals/east)
 "wir" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/grass,
 /area/magmoor/hydroponics)
@@ -30860,7 +30746,6 @@
 	},
 /area/magmoor/security/storage)
 "wog" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/blue/corner{
 	dir = 8
@@ -31088,7 +30973,6 @@
 /area/magmoor/cave/south)
 "wtS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/security/lobby)
@@ -31104,7 +30988,6 @@
 	},
 /area/magmoor/security)
 "wuc" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/carpet,
 /area/magmoor/command/conference)
@@ -31402,7 +31285,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/arrival/east)
@@ -31753,7 +31635,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -32007,15 +31888,6 @@
 	dir = 4
 	},
 /area/magmoor/compound)
-"wWj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 8
-	},
-/area/magmoor/compound/west)
 "wWy" = (
 /turf/open/lavaland/basalt/dirt/corner,
 /area/magmoor/compound/west)
@@ -32357,7 +32229,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
@@ -32709,7 +32580,6 @@
 /obj/machinery/alarm{
 	dir = 1
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/purple/taupepurple,
 /area/magmoor/civilian/jani)
@@ -33360,7 +33230,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean)
@@ -33645,7 +33514,6 @@
 "xUm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/civilian/dorms)
@@ -33722,7 +33590,6 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/commandroom)
 "xVk" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer,
 /turf/open/floor/mainship/blue{
 	dir = 6
 	},
@@ -33922,7 +33789,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/freezer,
 /area/magmoor/civilian/bar)
@@ -38721,7 +38587,7 @@ yla
 yla
 yla
 yla
-dlC
+yla
 yla
 uwV
 uwV
@@ -45978,7 +45844,7 @@ yeZ
 yeZ
 yeZ
 yeZ
-wWj
+yeZ
 rKb
 qKU
 uwV
@@ -47336,7 +47202,7 @@ bcM
 tpi
 yla
 xLM
-ugZ
+uhE
 oYj
 xLM
 wjZ
@@ -48271,7 +48137,7 @@ xLM
 uhg
 oYj
 xLM
-uDY
+wjZ
 jsC
 xLM
 oYj
@@ -48290,7 +48156,7 @@ xUm
 oYj
 xLM
 wjZ
-uRm
+jsC
 xLM
 oYj
 nic
@@ -50831,7 +50697,7 @@ riZ
 ucI
 rfG
 xLM
-iUo
+vqm
 oYj
 xLM
 wjZ
@@ -51772,7 +51638,7 @@ xLM
 oYj
 vqM
 xLM
-krc
+uhE
 oYj
 xLM
 wjZ
@@ -52494,7 +52360,7 @@ hjY
 qey
 hkW
 mtS
-imG
+xsi
 vme
 dfU
 ymc
@@ -58063,7 +57929,7 @@ uYC
 vnh
 pEr
 vFj
-efq
+wuc
 xZw
 wnp
 wuc

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -96,10 +96,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/magmoor/security/lobby)
-"agG" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/north)
 "ahk" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/light{
@@ -168,10 +164,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/east)
-"akX" = (
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/north)
 "alu" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /obj/effect/landmark/weed_node,
@@ -416,11 +408,6 @@
 /obj/item/tool/taperoll/police,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/security/infocenter)
-"axv" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/effect/decal/cleanable/rune,
-/turf/open/floor/cult,
-/area/magmoor/cave/northeast)
 "axw" = (
 /obj/item/ore/phoron,
 /turf/closed/mineral,
@@ -1010,14 +997,6 @@
 	dir = 8
 	},
 /area/magmoor/research/containment)
-"baU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/concrete/lines{
-	dir = 8
-	},
-/area/magmoor/compound/east)
 "bbj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -1437,10 +1416,6 @@
 	dir = 8
 	},
 /area/magmoor/cave/northeast)
-"byj" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/east)
 "byE" = (
 /obj/item/shard/phoron{
 	icon_state = "phoronsmall"
@@ -1734,7 +1709,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/miner,
 /turf/open/floor/plating/mainship,
 /area/magmoor/mining/garage)
 "bHM" = (
@@ -2423,7 +2397,6 @@
 /turf/open/floor/plating/mainship,
 /area/magmoor/mining/garage)
 "ciW" = (
-/obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/mono,
 /area/magmoor/mining)
@@ -2664,7 +2637,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/magmoor/research/decontamination)
 "csW" = (
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/decontamination)
@@ -2697,7 +2669,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 9
@@ -3140,7 +3111,6 @@
 	},
 /area/magmoor/security/infocenter)
 "cGp" = (
-/obj/effect/landmark/corpsespawner/miner,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 9
@@ -4083,7 +4053,6 @@
 /turf/open/floor/mainship/sterile/purple,
 /area/magmoor/research/lab)
 "djO" = (
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/research/lab)
@@ -5047,12 +5016,6 @@
 	dir = 8
 	},
 /area/magmoor/cave/central)
-"dOm" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/xeno_resin_wall,
-/turf/open/floor/cult,
-/area/magmoor/cave/northwest)
 "dOp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5384,7 +5347,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/floor,
 /area/magmoor/research/rnd)
@@ -5539,7 +5501,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -5958,7 +5919,6 @@
 "exg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -6298,7 +6258,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/treatment)
@@ -6358,7 +6317,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -6931,7 +6889,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/medical/breakroom)
@@ -8045,7 +8002,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
@@ -8618,7 +8574,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
@@ -8744,7 +8699,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 4
@@ -9443,7 +9397,6 @@
 "hcc" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/patient)
@@ -9679,7 +9632,6 @@
 	dir = 1;
 	on = 1
 	},
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/lobby)
@@ -10070,7 +10022,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/patient)
@@ -10186,7 +10137,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/doctor,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/chemistry)
@@ -10360,7 +10310,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/magmoor/research/researchdirector)
@@ -10391,7 +10340,6 @@
 	},
 /area/magmoor/cargo/storage/south)
 "hQk" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -11191,7 +11139,6 @@
 /turf/open/floor/freezer,
 /area/magmoor/civilian/bar)
 "ivV" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -11445,7 +11392,6 @@
 /turf/open/floor/plating,
 /area/magmoor/mining/refinery)
 "iFZ" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/yellow{
 	dir = 10
@@ -11872,7 +11818,6 @@
 	},
 /area/magmoor/mining/refinery)
 "iZV" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/magmoor/mining/refinery)
@@ -12194,7 +12139,6 @@
 	},
 /area/magmoor/engi/power)
 "jkm" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 1
@@ -12462,7 +12406,6 @@
 /turf/closed/glass/thin/straight,
 /area/magmoor/cave/west)
 "jru" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/sterile/dark,
 /area/magmoor/medical/lobby)
@@ -13468,7 +13411,6 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -14531,7 +14473,6 @@
 /turf/open/lavaland/lava/single/middle,
 /area/magmoor/cave/east)
 "kYR" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/lavaland/catwalk,
 /area/magmoor/cave/west)
@@ -16696,7 +16637,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/floor,
 /area/magmoor/cargo/storage/secure)
@@ -16842,7 +16782,6 @@
 /turf/open/floor/plating,
 /area/magmoor/engi/power)
 "mOH" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 4
@@ -17088,11 +17027,6 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/magmoor/mining/storage)
-"mXv" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/effect/decal/cleanable/rune,
-/turf/open/floor/cult,
-/area/magmoor/cave/north)
 "mXC" = (
 /turf/open/floor/plating/ground/dirtgrassborder2{
 	dir = 8
@@ -17405,7 +17339,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 8
@@ -17899,7 +17832,6 @@
 /turf/open/floor/mainship/orange,
 /area/magmoor/cargo/storage/south)
 "nFD" = (
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/orange{
 	dir = 4
@@ -18512,7 +18444,6 @@
 	},
 /area/magmoor/compound/southwest)
 "oaJ" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/mainship/orange{
 	dir = 8
@@ -18730,7 +18661,6 @@
 /area/magmoor/cave/southwest)
 "oiP" = (
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/magmoor/engi/power)
@@ -20239,7 +20169,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/engineer,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/edge{
 	dir = 1
@@ -20530,7 +20459,6 @@
 /turf/open/floor/grass,
 /area/magmoor/hydroponics)
 "pue" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/cave/southeast)
@@ -25115,7 +25043,6 @@
 /turf/open/floor/freezer,
 /area/magmoor/cargo/freezer)
 "sBS" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/freezer,
 /area/magmoor/cargo/freezer)
@@ -43150,7 +43077,7 @@ ryj
 afo
 afo
 afo
-dOm
+ryj
 aum
 nqC
 aLp
@@ -47113,7 +47040,7 @@ afe
 urr
 urr
 urr
-mXv
+afe
 aMD
 aMD
 qkn
@@ -47340,7 +47267,7 @@ qkn
 qkn
 qkn
 aMD
-akX
+aMD
 aMD
 aMD
 urr
@@ -51766,7 +51693,7 @@ fCk
 qkn
 qkn
 aMD
-agG
+aMD
 aih
 aMD
 aMD
@@ -56898,7 +56825,7 @@ idd
 idd
 idd
 idd
-axv
+aqg
 idd
 idd
 anJ
@@ -65562,7 +65489,7 @@ pwz
 mky
 eEq
 eEq
-byj
+eEq
 eEq
 eEq
 eEq
@@ -72631,7 +72558,7 @@ wqW
 fLG
 fLG
 fLG
-baU
+fLG
 tyL
 jlp
 oJl

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -24400,12 +24400,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
-"bxR" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/prison/red{
-	dir = 8
-	},
-/area/prison/cellblock/highsec/north/south)
 "bxS" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/prison/darkred,
@@ -30610,10 +30604,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison,
 /area/prison/intake)
-"bRS" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/prison/bright_clean,
-/area/prison/hallway/central)
 "bRT" = (
 /obj/machinery/light{
 	dir = 8
@@ -42573,12 +42563,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
-"lGC" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/prison/yellow/corner{
-	dir = 1
-	},
-/area/prison/cellblock/mediumsec/south)
 "lOX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -42804,10 +42788,6 @@
 	dir = 6
 	},
 /area/prison/security/checkpoint/highsec/s)
-"mYx" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/residential/south)
 "mYC" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -43693,12 +43673,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/research/secret/biolab)
-"sgC" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/prison/yellow{
-	dir = 4
-	},
-/area/prison/cellblock/mediumsec/east)
 "shF" = (
 /turf/open/ground/desertdam/river/clean/shallow_edge,
 /area/prison/hallway/central)
@@ -44266,10 +44240,6 @@
 	dir = 4
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
-"vSz" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/hallway/central)
 "vSO" = (
 /obj/structure/window/framed/prison/reinforced,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -51487,7 +51457,7 @@ bCb
 bCb
 bCb
 bCb
-mYx
+bCb
 bWC
 klX
 bLL
@@ -64278,7 +64248,7 @@ aCg
 aCg
 aCg
 aCg
-bxR
+aCg
 aCg
 aCg
 aCg
@@ -75587,7 +75557,7 @@ aIS
 aKO
 aCe
 aKP
-bRS
+aKP
 aKP
 aKP
 aKP
@@ -81293,7 +81263,7 @@ aKS
 aKS
 aKS
 aMe
-vSz
+aKN
 bPL
 bPO
 bRo
@@ -82370,7 +82340,7 @@ cvc
 cvc
 cvc
 cvW
-lGC
+cxQ
 cvA
 ctb
 cvA
@@ -85187,7 +85157,7 @@ ctz
 cqR
 cqR
 cqR
-sgC
+cqR
 tqX
 cqR
 cqR

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -10635,10 +10635,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/n)
-"aHB" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/plate,
-/area/prison/recreation/highsec/n)
 "aHC" = (
 /obj/structure/table/woodentable,
 /obj/item/paper,
@@ -10966,13 +10962,6 @@
 "aIC" = (
 /turf/open/floor/prison/rampbottom,
 /area/prison/residential/central)
-"aID" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/highsec/north/south)
 "aIE" = (
 /turf/closed/wall/prison,
 /area/prison/medbay/foyer)
@@ -11116,7 +11105,6 @@
 /area/prison/security/checkpoint/maxsec)
 "aIZ" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/prison/whitegreen{
 	dir = 10
 	},
@@ -12132,10 +12120,6 @@
 	dir = 5
 	},
 /area/prison/cellblock/highsec/north/south)
-"aLQ" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/plating,
-/area/prison/cellblock/highsec/north/south)
 "aLR" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/prison/darkyellow,
@@ -12416,12 +12400,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/residential/north)
-"aMI" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/cellstripe{
-	dir = 4
-	},
-/area/prison/cellblock/highsec/north/south)
 "aMJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14725,10 +14703,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/cellstripe,
 /area/prison/cellblock/highsec/north/south)
-"aUd" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/highsec/north/south)
 "aUe" = (
 /obj/machinery/shower{
 	dir = 4
@@ -17010,12 +16984,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
-"bbb" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/cellstripe{
-	dir = 8
-	},
-/area/prison/cellblock/highsec/north/south)
 "bbc" = (
 /obj/structure/toilet,
 /turf/open/floor/prison/cellstripe{
@@ -17271,17 +17239,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/darkred,
 /area/prison/security/monitoring/highsec)
-"bbY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/highsec/north/south)
-"bbZ" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/highsec/north/south)
 "bca" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -26943,17 +26900,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
-"bFQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/red,
-/area/prison/cellblock/highsec/south/north)
 "bFR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -27336,12 +27282,6 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
-"bHh" = (
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/prison/cellblock/highsec/south/north)
 "bHi" = (
 /turf/open/floor/prison/red/corner{
 	dir = 4
@@ -27707,7 +27647,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/red/corner{
 	dir = 8
 	},
@@ -30837,7 +30776,6 @@
 /obj/structure/bed/chair/office/dark,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs,
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/darkred,
 /area/prison/security/monitoring/lowsec/sw)
 "bSA" = (
@@ -31254,12 +31192,6 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
-"bTU" = (
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/red/corner{
-	dir = 4
-	},
-/area/prison/cellblock/highsec/south/north)
 "bTV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -31309,10 +31241,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/plate,
-/area/prison/recreation/highsec/s)
-"bUd" = (
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison,
 /area/prison/recreation/highsec/s)
 "bUe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -33996,10 +33924,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/recreation/medsec)
-"ccN" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/lowsec/nw)
 "ccO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -34067,13 +33991,6 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/north)
-"ccX" = (
-/obj/structure/sink{
-	dir = 8
-	},
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/mediumsec/south)
 "ccY" = (
 /obj/machinery/alarm,
 /turf/open/floor/plating,
@@ -35168,10 +35085,6 @@
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
-"cgb" = (
-/obj/effect/landmark/corpsespawner/pirate,
-/turf/open/floor/plating,
-/area/prison/cellblock/highsec/south/south)
 "cgd" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -35213,10 +35126,6 @@
 /area/prison/cellblock/highsec/south/south)
 "cgl" = (
 /obj/item/ammo_casing,
-/turf/open/floor/prison/red,
-/area/prison/cellblock/highsec/south/south)
-"cgm" = (
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/south/south)
 "cgp" = (
@@ -35493,7 +35402,6 @@
 /turf/open/floor/plating,
 /area/prison/pirate)
 "chi" = (
-/obj/effect/landmark/corpsespawner/prison_security,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/plating,
@@ -35505,7 +35413,6 @@
 /area/prison/pirate)
 "chk" = (
 /obj/effect/decal/warning_stripes/thin,
-/obj/effect/landmark/corpsespawner/prison_security,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/plating,
@@ -35521,7 +35428,6 @@
 /area/prison/pirate)
 "chn" = (
 /obj/effect/decal/warning_stripes/thin,
-/obj/effect/landmark/corpsespawner/prison_security,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/plating,
@@ -35856,7 +35762,6 @@
 /area/prison/pirate)
 "cir" = (
 /obj/machinery/door/poddoor/two_tile_hor/rocinante,
-/obj/effect/landmark/corpsespawner/prison_security,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/marking/delivery,
@@ -35882,7 +35787,6 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
 "cix" = (
-/obj/effect/landmark/corpsespawner/pirate,
 /obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/prison/red{
 	dir = 1
@@ -36185,7 +36089,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/effect/landmark/corpsespawner/prison_security,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/plating,
@@ -36732,7 +36635,6 @@
 /area/prison/parole/protective_custody)
 "cld" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
-/obj/effect/landmark/corpsespawner/pirate,
 /obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/prison/red{
 	dir = 9
@@ -36914,7 +36816,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/highsec_medsec)
 "clE" = (
@@ -37435,7 +37336,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
@@ -37887,12 +37787,6 @@
 "cox" = (
 /obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/prison/red/corner{
-	dir = 1
-	},
-/area/prison/cellblock/highsec/south/south)
-"coy" = (
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/red{
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/south)
@@ -38734,12 +38628,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/north)
-"crv" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/cellstripe{
-	dir = 4
-	},
-/area/prison/cellblock/mediumsec/north)
 "crw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -39562,7 +39450,6 @@
 	dir = 4;
 	on = 1
 	},
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/yellow{
 	dir = 8
 	},
@@ -39958,11 +39845,6 @@
 "cvA" = (
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
-"cvB" = (
-/obj/structure/bed,
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/mediumsec/south)
 "cvC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -40136,7 +40018,6 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/east)
 "cwe" = (
-/obj/effect/landmark/corpsespawner/prison_security,
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/plating,
@@ -40244,7 +40125,6 @@
 /area/prison/pirate)
 "cwu" = (
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/prison_security,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
@@ -40433,11 +40313,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/west)
-"cxl" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/mediumsec/south)
 "cxm" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/plate,
@@ -40539,11 +40414,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
-"cxS" = (
-/obj/structure/bed,
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/mediumsec/east)
 "cxT" = (
 /turf/open/floor/prison/yellow{
 	dir = 10
@@ -40720,12 +40590,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison/yellow{
-	dir = 4
-	},
-/area/prison/cellblock/mediumsec/south)
-"cyW" = (
-/obj/effect/landmark/corpsespawner/prisoner,
-/turf/open/floor/prison/cellstripe{
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
@@ -41045,7 +40909,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/medsec/south)
 "czU" = (
@@ -42618,12 +42481,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/prison,
 /area/prison/execution)
-"mrj" = (
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/yellow/corner{
-	dir = 8
-	},
-/area/prison/cellblock/mediumsec/south)
 "mrt" = (
 /obj/effect/decal/woodsiding{
 	dir = 8
@@ -43605,10 +43462,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/biolab)
-"rFI" = (
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/bright_clean,
-/area/prison/hallway/central)
 "rGJ" = (
 /obj/machinery/power/apc/drained{
 	dir = 1
@@ -63473,7 +63326,7 @@ axJ
 aEP
 aGb
 aCl
-aID
+aEP
 aGb
 aCl
 aEP
@@ -64809,7 +64662,7 @@ bvA
 bVw
 bvA
 byC
-bFQ
+bFT
 bvA
 bPg
 bwC
@@ -65033,7 +64886,7 @@ aCl
 aKx
 aCl
 bac
-bbb
+aDR
 aDR
 aHw
 bdI
@@ -65349,7 +65202,7 @@ cil
 cbc
 cbc
 clg
-cgb
+cbc
 clC
 cbc
 cbc
@@ -66305,7 +66158,7 @@ aEQ
 aGc
 aCl
 aHv
-aMI
+aEQ
 aGc
 aCl
 aOF
@@ -66876,7 +66729,7 @@ bwz
 oaU
 bwz
 bwz
-bTU
+bHi
 bKs
 bWP
 bYA
@@ -67378,7 +67231,7 @@ bCf
 bwA
 buv
 bvA
-bHh
+byC
 bFZ
 bwH
 bwA
@@ -67604,7 +67457,7 @@ aLO
 aES
 aWA
 bbd
-bbY
+aJQ
 aEO
 bdN
 bfc
@@ -67913,7 +67766,7 @@ cbe
 ccI
 cbc
 ceA
-cgb
+cbc
 chm
 cir
 cjw
@@ -68360,7 +68213,7 @@ aCo
 aBg
 aKx
 aCl
-aLQ
+aKx
 aCl
 aLO
 aDS
@@ -69383,7 +69236,7 @@ aCp
 aDV
 aEZ
 aGk
-aHB
+aDV
 aIG
 aBg
 aKA
@@ -69917,7 +69770,7 @@ aLO
 aES
 aEV
 bbc
-bbZ
+aGb
 aGh
 bdN
 bfb
@@ -70681,7 +70534,7 @@ aPi
 aQE
 aCl
 aSX
-aUd
+aDS
 aVt
 aWA
 aLO
@@ -71502,7 +71355,7 @@ bOp
 bOm
 bOm
 bSw
-bUd
+bSw
 bOm
 bOm
 bOm
@@ -71520,7 +71373,7 @@ bYC
 bYC
 bYC
 bYC
-coy
+coz
 clO
 bZW
 cqK
@@ -72025,7 +71878,7 @@ bYC
 bYC
 bYC
 coz
-cgm
+cba
 bYC
 bYC
 bYC
@@ -74806,7 +74659,7 @@ bsY
 aWG
 aKN
 aKN
-bzV
+aKP
 aKP
 aKN
 aKN
@@ -74869,7 +74722,7 @@ ccW
 crY
 csE
 ctg
-mrj
+ctU
 cuo
 cuP
 cuP
@@ -76671,7 +76524,7 @@ cnB
 ctT
 cun
 ybf
-cvB
+cuL
 cun
 ccB
 cuL
@@ -76934,7 +76787,7 @@ cuM
 cvA
 cun
 cuM
-cxl
+cyG
 cun
 cxz
 ctj
@@ -77875,7 +77728,7 @@ jNw
 aNU
 aPz
 aQS
-ccN
+aPC
 aPC
 aUr
 aPC
@@ -81042,7 +80895,7 @@ cun
 ccB
 cuL
 cun
-ccX
+ccB
 cuL
 cun
 ccB
@@ -81547,7 +81400,7 @@ ccV
 ckq
 cln
 ccV
-crv
+ckq
 cln
 ccV
 cnB
@@ -81571,7 +81424,7 @@ cun
 cuN
 cuV
 cun
-cyW
+cuN
 cuV
 cun
 cxz
@@ -81771,7 +81624,7 @@ bDW
 aXw
 vSO
 aKP
-rFI
+aKP
 aLs
 aKN
 bsY
@@ -83875,7 +83728,7 @@ cpU
 cpV
 ccJ
 cpU
-cxS
+cpV
 ccJ
 jSF
 cyx
@@ -84123,7 +83976,7 @@ cqd
 coI
 cua
 cpU
-cve
+cqf
 cqO
 cpU
 cqf

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -287,27 +287,10 @@
 "bD" = (
 /turf/open/floor/tile/dark,
 /area/outpost/science)
-"bE" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Bren Foras"
-	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/outpost/yard/west)
 "bF" = (
 /obj/structure/cable,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/cargo)
-"bI" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Chang Lin"
-	},
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/south_east)
 "bL" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
@@ -423,10 +406,6 @@
 "cq" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/caves/north_west)
-"cs" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_east)
 "cv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
@@ -1244,12 +1223,6 @@
 	},
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/central)
-"gO" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 4
-	},
-/area/outpost/yard/central)
 "gP" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
@@ -1351,21 +1324,9 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
-"hr" = (
-/obj/effect/landmark/corpsespawner/chef,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/yard/south_east)
 "hs" = (
 /turf/open/floor/plating/dmg1,
 /area/outpost/arrivals)
-"hu" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Laborer";
-	name = "Colonist Roester Kalin"
-	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/outpost/lz1)
 "hv" = (
 /obj/machinery/light{
 	dir = 1
@@ -2011,18 +1972,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/red2,
 /area/outpost/brig)
-"kG" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpsebelt = /obj/item/storage/belt/medical;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpsepocket2 = /obj/item/storage/pouch/medkit/full;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit/doctor;
-	name = "Colonist Doctor"
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_east)
 "kH" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
@@ -3823,12 +3772,6 @@
 	dir = 4
 	},
 /area/outpost/lz1)
-"uo" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
-/area/outpost/caves/east)
 "up" = (
 /obj/machinery/landinglight/ds2{
 	dir = 1
@@ -4808,16 +4751,6 @@
 	dir = 10
 	},
 /area/outpost/arrivals)
-"zY" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpsehelmet = /obj/item/clothing/head/welding;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Ted Jarka"
-	},
-/turf/open/floor/plating/asteroidwarning,
-/area/outpost/yard/central)
 "zZ" = (
 /turf/closed/wall/r_wall,
 /area/outpost/science/research)
@@ -5500,16 +5433,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
-"Ea" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	name = "Colonist Mio Linno"
-	},
-/turf/open/floor/marking/asteroidwarning{
-	dir = 1
-	},
-/area/outpost/yard/east)
 "Eb" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/lz1)
@@ -6443,7 +6366,6 @@
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "Jk" = (
-/obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
@@ -20599,7 +20521,7 @@ XE
 XE
 sv
 Hc
-hu
+Hc
 yc
 XS
 Ql
@@ -23944,7 +23866,7 @@ Jb
 Jb
 Jb
 Jb
-bE
+Jb
 Jb
 bx
 Jb
@@ -30132,7 +30054,7 @@ EA
 oM
 bP
 hB
-gO
+hB
 hB
 hB
 hB
@@ -31162,7 +31084,7 @@ ew
 Fc
 Fc
 bP
-zY
+CY
 EA
 fG
 HT
@@ -35306,7 +35228,7 @@ fG
 fG
 NF
 NF
-hr
+NF
 NF
 NF
 NF
@@ -36322,7 +36244,7 @@ ye
 GY
 rL
 QL
-Ea
+mH
 sK
 fG
 vd
@@ -37074,7 +36996,7 @@ mM
 Yx
 TP
 Yx
-kG
+Yx
 Yx
 Js
 hS
@@ -38397,7 +38319,7 @@ ZQ
 Ar
 xg
 xg
-uo
+xg
 xg
 xg
 xg
@@ -38610,7 +38532,7 @@ Cx
 Cx
 Cx
 Yo
-cs
+Yx
 WB
 WB
 Yx
@@ -38929,7 +38851,7 @@ eA
 uf
 fd
 UT
-bI
+UT
 UT
 EZ
 Hm

--- a/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
+++ b/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
@@ -452,30 +452,11 @@
 "bG" = (
 /turf/closed/mineral,
 /area/lv624/ground/caves/east1)
-"bH" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Braxton Oxto"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/east1)
 "bI" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Kira Von"
-	},
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
 "bJ" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Bren Foras"
-	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
 "bK" = (
@@ -1107,7 +1088,6 @@
 /area/medical/medbay2)
 "ey" = (
 /obj/structure/closet/bodybag/cryobag,
-/obj/effect/landmark/corpsespawner/miner/rig,
 /turf/open/floor/tile/bar,
 /area/medical/medbay2)
 "ez" = (
@@ -1353,15 +1333,6 @@
 	dir = 1
 	},
 /area/vapor_processing/cargo2)
-"fv" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
-	corpsesuit = /obj/item/clothing/suit/storage/CMB;
-	corpseuniform = /obj/item/clothing/under/CM_uniform;
-	name = "Marshal Logan Bills"
-	},
-/turf/open/floor/plating,
-/area/maintenance/apmaint)
 "fw" = (
 /obj/structure/closet/secure_closet/shiptech,
 /obj/machinery/light{
@@ -1407,14 +1378,6 @@
 	dir = 1
 	},
 /area/lv624/lazarus/quartstorage)
-"fM" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Olgin Vekin"
-	},
-/turf/open/ground,
-/area/lv624/ground/caves/west1)
 "fN" = (
 /obj/machinery/door/airlock/glass_mining,
 /turf/open/floor/plating,
@@ -1483,7 +1446,6 @@
 /area/lv624/lazarus/medbay)
 "gf" = (
 /obj/machinery/sleeper,
-/obj/effect/landmark/corpsespawner/prisoner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/medbay)
@@ -1500,7 +1462,6 @@
 /area/lv624/lazarus/medbay)
 "gi" = (
 /obj/machinery/sleeper,
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/medbay)
 "gj" = (
@@ -1526,66 +1487,7 @@
 /obj/structure/closet/secure_closet/medical_doctor,
 /turf/open/floor/tile/green/whitegreen,
 /area/lv624/lazarus/medbay)
-"gp" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Evan Kark"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/space)
-"gq" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpseidjob = "Doctor";
-	name = "Colonist Drew Bellel"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/space)
-"gr" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Jac Mester"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/space)
-"gs" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpsehelmet = /obj/item/clothing/head/tgmccap/req;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Lee Hesto"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/ground,
-/area/space)
-"gt" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Ellis Bark"
-	},
-/turf/open/ground,
-/area/space)
-"gu" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Olgin Vekin"
-	},
-/turf/open/ground,
-/area/space)
 "gv" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Chang Lin"
-	},
 /obj/item/weapon/gun/pistol/holdout,
 /turf/open/ground,
 /area/space)
@@ -1599,57 +1501,10 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground,
 /area/space)
-"gy" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Wes Uvin"
-	},
-/turf/open/ground,
-/area/space)
-"gB" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpsehelmet = /obj/item/clothing/head/welding;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Ted Jarka"
-	},
-/turf/open/ground,
-/area/space)
-"gC" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Everett Mison"
-	},
-/turf/open/ground,
-/area/space)
-"gD" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpseidjob = "Doctor";
-	name = "Colonist Ted Koso"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/ground,
-/area/space)
 "gF" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground,
-/area/space)
-"gG" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack;
-	corpsehelmet = /obj/item/clothing/head/flatcap;
-	corpseidjob = "Laborer";
-	name = "Colonist Terrin Yin"
-	},
 /turf/open/ground,
 /area/space)
 "gH" = (
@@ -1660,52 +1515,9 @@
 "gI" = (
 /turf/open/floor/plating/ground/dirt,
 /area/space)
-"gJ" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Marko Quin"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/space)
-"gK" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpsehelmet = /obj/item/clothing/head/flatcap;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Jackson Martin"
-	},
-/turf/open/ground,
-/area/space)
-"gL" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpsehelmet = /obj/item/clothing/head/tgmccap/req;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Olin Berus"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/space)
 "gM" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
-	corpsesuit = /obj/item/clothing/suit/storage/CMB;
-	corpseuniform = /obj/item/clothing/under/CM_uniform;
-	name = "Deputy Maxwell Ligis"
-	},
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/ground,
-/area/space)
-"gN" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpsehelmet = /obj/item/clothing/head/soft/grey;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Innio Morris"
-	},
-/turf/open/floor/plating/ground/dirt,
 /area/space)
 "gO" = (
 /obj/structure/table,
@@ -1720,14 +1532,6 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
-"gR" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpsehelmet = /obj/item/clothing/head/helmet/riot;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Fors Ilin"
-	},
-/turf/open/ground,
-/area/space)
 "gS" = (
 /turf/open/floor/tile/whiteyellow/corner{
 	dir = 1
@@ -1739,14 +1543,6 @@
 	dir = 1
 	},
 /area/vapor_processing/cargo2)
-"gU" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Laborer";
-	name = "Colonist Roester Kalin"
-	},
-/turf/open/ground,
-/area/lv624/ground/caves/central2)
 "gV" = (
 /obj/structure/table/flipped,
 /obj/structure/cable,
@@ -1819,10 +1615,6 @@
 /obj/effect/landmark/itemspawner/butler,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
-"hj" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/ground,
-/area/lv624/ground/caves/west1)
 "hk" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/technology_scanner,
@@ -1952,14 +1744,6 @@
 	},
 /turf/open/floor/tile/green/whitegreen,
 /area/medical/medbay2)
-"hM" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Kira Von"
-	},
-/turf/open/ground,
-/area/lv624/ground/caves/central1)
 "hN" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/toolbox,
@@ -2012,14 +1796,6 @@
 /obj/effect/landmark/corpsespawner/syndicatesoldier,
 /turf/open/ground,
 /area/lv624/ground/caves/east1)
-"hY" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Bren Foras"
-	},
-/turf/open/ground,
-/area/lv624/ground/caves/central1)
 "hZ" = (
 /obj/structure/largecrate,
 /turf/open/floor/tile/whiteyellow/corner{
@@ -2127,24 +1903,6 @@
 /obj/structure/closet/secure_closet/detective,
 /turf/open/floor/tile/red/redtaupe,
 /area/lv624/lazarus/security)
-"iv" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpseidjob = "Doctor";
-	name = "Colonist Drew Bellel"
-	},
-/turf/open/floor/tile/white,
-/area/medical/medbay2)
-"ix" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack;
-	corpsehelmet = /obj/item/clothing/head/flatcap;
-	corpseidjob = "Laborer";
-	name = "Colonist Terrin Yin"
-	},
-/turf/open/ground,
-/area/lv624/ground/caves/east1)
 "iy" = (
 /obj/machinery/power/geothermal,
 /obj/structure/cable,
@@ -2172,29 +1930,10 @@
 /obj/effect/landmark/corpsespawner/syndicatecommando,
 /turf/open/ground,
 /area/lv624/ground/caves/east1)
-"iF" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	name = "Colonist Ben Harris"
-	},
-/turf/open/floor/tile/green/whitegreen,
-/area/medical/medbay2)
 "iG" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/green/whitegreen,
 /area/medical/medbay2)
-"iH" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/green/whitegreen,
-/area/medical/medbay2)
-"iI" = (
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/engineer/rig,
-/turf/open/floor/tile/whiteyellow/corner{
-	dir = 1
-	},
-/area/lv624/lazarus/quartstorage)
 "iJ" = (
 /obj/structure/dispenser,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2842,15 +2581,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/comms)
-"lp" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Wes Uvin"
-	},
-/turf/open/floor/grass,
-/area/vapor_processing/east_compound)
 "lq" = (
 /obj/structure/largecrate/random,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2888,10 +2618,6 @@
 	dir = 1
 	},
 /area/vapor_processing/cargo2)
-"ly" = (
-/obj/effect/landmark/corpsespawner/clown,
-/turf/open/floor/tile/green/whitegreen,
-/area/lv624/lazarus/medbay)
 "lA" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -3262,12 +2988,6 @@
 /obj/machinery/power/smes/buildable,
 /turf/open/floor,
 /area/maintenance/substation)
-"nq" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/whiteyellow/corner{
-	dir = 1
-	},
-/area/lv624/lazarus/quart)
 "nr" = (
 /obj/structure/table/flipped,
 /obj/item/rsf,
@@ -3446,34 +3166,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/ground,
 /area/vapor_processing/caves/se)
-"op" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Kegan Mills"
-	},
-/turf/open/ground,
-/area/vapor_processing/caves/se)
-"oq" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
-	corpsesuit = /obj/item/clothing/suit/storage/CMB;
-	corpseuniform = /obj/item/clothing/under/CM_uniform;
-	name = "Marshal Logan Bills"
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/ground,
-/area/vapor_processing/caves/se)
-"or" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Harry Trent"
-	},
-/turf/open/ground,
-/area/vapor_processing/caves/se)
 "ot" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -3533,14 +3225,6 @@
 "oK" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground,
-/area/vapor_processing/caves/se)
-"oM" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	name = "Colonist Redo Koster"
-	},
 /turf/open/ground,
 /area/vapor_processing/caves/se)
 "oN" = (
@@ -3611,16 +3295,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/grass,
 /area/lv624/ground/compound/c)
-"pb" = (
-/obj/effect/landmark/corpsespawner/scientist{
-	corpseback = null;
-	corpsebelt = /obj/item/weapon/gun/pistol/holdout;
-	corpseshoes = /obj/item/clothing/shoes/black;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Luther Yovin"
-	},
-/turf/open/ground,
-/area/vapor_processing/caves/se)
 "pc" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -3645,29 +3319,6 @@
 /obj/structure/cable,
 /turf/closed/wall/wood,
 /area/crew_quarters/sleep_male)
-"ph" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	name = "Colonist Ben Harris"
-	},
-/turf/open/ground,
-/area/vapor_processing/caves/se)
-"pi" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	name = "Colonist Mio Linno"
-	},
-/turf/open/ground,
-/area/vapor_processing/caves/se)
-"pj" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Ethan Peser"
-	},
-/turf/open/ground,
-/area/vapor_processing/caves/se)
 "pk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -4290,12 +3941,6 @@
 	dir = 1
 	},
 /area/vapor_processing/cargo3)
-"rA" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/whiteyellow/corner{
-	dir = 1
-	},
-/area/vapor_processing/cargo3)
 "rB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4312,14 +3957,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/yellow,
 /area/lv624/lazarus/engineering)
-"rE" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	name = "Colonist Mio Linno"
-	},
-/turf/open/floor/tile/red/redtaupe,
-/area/lv624/lazarus/security)
 "rF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -4455,14 +4092,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/carpet,
 /area/lv624/lazarus/canteen)
-"sb" = (
-/obj/effect/landmark/corpsespawner/chef{
-	corpsesuit = null;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Jed Willis"
-	},
-/turf/open/floor/carpet,
-/area/lv624/lazarus/canteen)
 "sc" = (
 /obj/machinery/firealarm,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4503,7 +4132,6 @@
 /area/lv624/lazarus/comms)
 "sg" = (
 /obj/structure/window/reinforced,
-/obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/carpet,
 /area/lv624/lazarus/canteen)
 "sh" = (
@@ -4512,18 +4140,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/comms)
-"si" = (
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpsehelmet = /obj/item/clothing/head/welding;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Ted Jarka"
-	},
-/turf/open/floor/tile/whiteyellow/corner{
-	dir = 1
-	},
-/area/vapor_processing/cargo3)
 "sj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -4540,18 +4156,6 @@
 /area/lv624/lazarus/engineering)
 "sl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/prison/yellow/full,
-/area/lv624/lazarus/engineering)
-"sm" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/engineer{
-	corpseback = /obj/item/storage/backpack;
-	corpseidjob = "Engineer";
-	corpseshoes = /obj/item/clothing/shoes/black;
-	name = "Colonist Everett Mison"
-	},
 /turf/open/floor/prison/yellow/full,
 /area/lv624/lazarus/engineering)
 "sn" = (
@@ -4599,15 +4203,6 @@
 	dir = 8
 	},
 /area/lv624/lazarus/engineering)
-"su" = (
-/obj/effect/landmark/corpsespawner/doctor{
-	corpseback = null;
-	corpsegloves = /obj/item/clothing/gloves/latex;
-	corpseidjob = "Doctor";
-	name = "Colonist Ted Koso"
-	},
-/turf/open/ground,
-/area/lv624/ground/compound/sw)
 "sv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/grass,
@@ -4707,14 +4302,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/grass,
 /area/vapor_processing/south_compound)
-"sH" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpsehelmet = /obj/item/clothing/head/helmet/riot;
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Fors Ilin"
-	},
-/turf/open/floor/plating,
-/area/vapor_processing/cargo_maint_s)
 "sI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -4737,13 +4324,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor,
 /area/storage/tools)
-"sL" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Ethan Peser"
-	},
-/turf/open/floor,
-/area/shuttle/drop1/lz1)
 "sM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/closed/wall,
@@ -4855,13 +4435,6 @@
 	},
 /turf/closed/wall,
 /area/lv624/lazarus/engineering)
-"tg" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Jac Mester"
-	},
-/turf/open/floor/plating,
-/area/vapor_processing/cargo_maint_s)
 "th" = (
 /obj/structure/table/flipped,
 /obj/effect/spawner/random/bomb_supply,
@@ -5122,12 +4695,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/corpsespawner/security{
-	corpsebelt = null;
-	corpsesuit = /obj/item/clothing/suit/storage/CMB;
-	corpseuniform = /obj/item/clothing/under/CM_uniform;
-	name = "Deputy Edgar Nogi"
-	},
 /turf/open/floor/plating,
 /area/vapor_processing/cargo_maint_s)
 "uf" = (
@@ -5176,16 +4743,6 @@
 	},
 /turf/open/floor/wood/broken,
 /area/crew_quarters/sleep/bedrooms)
-"um" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/corpsespawner/security{
-	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
-	corpsesuit = /obj/item/clothing/suit/storage/CMB;
-	corpseuniform = /obj/item/clothing/under/CM_uniform;
-	name = "Deputy Maxwell Ligis"
-	},
-/turf/open/floor/plating,
-/area/vapor_processing/cargo_maint_s)
 "un" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/lazarus/fitness)
@@ -6265,7 +5822,7 @@ eK
 hT
 og
 it
-rE
+it
 it
 it
 it
@@ -6279,7 +5836,7 @@ lv
 lv
 lv
 lv
-sL
+mc
 mc
 mc
 mc
@@ -6375,7 +5932,7 @@ jY
 qy
 kB
 hT
-su
+kQ
 kQ
 lt
 lv
@@ -6557,7 +6114,7 @@ ah
 ah
 dX
 ec
-iv
+ev
 eD
 eD
 eV
@@ -6661,7 +6218,7 @@ dX
 ed
 ev
 ee
-iF
+ee
 ee
 dX
 eK
@@ -6888,7 +6445,7 @@ iB
 ki
 ki
 lt
-sH
+lv
 lv
 lt
 mc
@@ -7075,7 +6632,7 @@ fm
 fD
 fD
 fD
-ly
+fD
 ht
 fC
 eK
@@ -7172,7 +6729,7 @@ eg
 ex
 eH
 ee
-iH
+ee
 ee
 fD
 fD
@@ -7846,7 +7403,7 @@ aa
 aa
 ae
 aC
-fv
+ba
 ba
 bi
 bi
@@ -7918,7 +7475,7 @@ lv
 mt
 lD
 lt
-tg
+lv
 lC
 lv
 lC
@@ -7940,7 +7497,7 @@ lt
 lC
 lv
 lv
-um
+lA
 lt
 aa
 "}
@@ -8001,7 +7558,7 @@ eK
 em
 iB
 qk
-sb
+jr
 qq
 qw
 iO
@@ -9180,7 +8737,7 @@ ab
 ab
 bb
 bb
-fM
+bb
 ab
 ab
 ab
@@ -10028,12 +9585,12 @@ ep
 ep
 eL
 eT
-iI
+ff
 fs
 fs
 fW
 gS
-nq
+gS
 gS
 rb
 gS
@@ -10521,7 +10078,7 @@ bg
 bg
 bb
 bb
-hj
+bb
 bb
 ab
 ab
@@ -10654,7 +10211,7 @@ im
 rH
 im
 im
-si
+im
 hO
 ep
 ep
@@ -10815,7 +10372,7 @@ ac
 bh
 bh
 Gn
-gU
+bc
 bc
 bB
 bB
@@ -10854,7 +10411,7 @@ GV
 hP
 rv
 im
-rA
+im
 rH
 im
 im
@@ -11951,7 +11508,7 @@ bB
 bB
 bD
 UJ
-hM
+bB
 bB
 bB
 UJ
@@ -12162,7 +11719,7 @@ bB
 bB
 UJ
 bD
-hY
+bB
 bB
 bD
 bB
@@ -13193,7 +12750,7 @@ eU
 eO
 eO
 eO
-lp
+eN
 fY
 fY
 hG
@@ -13660,18 +13217,18 @@ aa
 aa
 aa
 aa
-gp
+gI
 gx
 bd
 gv
 af
-gC
-gD
-gG
+af
+cv
+af
 gI
-gJ
-gL
-gN
+gI
+gI
+gI
 gx
 bG
 bG
@@ -13715,7 +13272,7 @@ rM
 jk
 hG
 hG
-sm
+hr
 gY
 fY
 eN
@@ -13762,7 +13319,7 @@ aa
 aa
 aa
 aa
-gq
+gI
 ct
 af
 gw
@@ -13775,7 +13332,7 @@ CU
 CU
 af
 gx
-bH
+bJ
 bG
 bF
 bG
@@ -13864,7 +13421,7 @@ aa
 aa
 aa
 aa
-gr
+gI
 gx
 af
 CU
@@ -13968,7 +13525,7 @@ aa
 aa
 ag
 gx
-gs
+cv
 CU
 af
 af
@@ -14070,7 +13627,7 @@ aa
 aa
 ag
 gx
-gt
+af
 CU
 CU
 CU
@@ -14172,16 +13729,16 @@ aa
 aa
 ag
 gx
-gu
-gy
-gB
+af
+af
+af
 CU
 af
 af
 CU
-gK
+af
 gM
-gR
+af
 gx
 bE
 bE
@@ -14207,7 +13764,7 @@ bG
 bF
 bF
 bF
-ix
+bE
 bE
 bF
 bF
@@ -15169,13 +14726,13 @@ li
 li
 li
 Jt
-op
-oC
-fB
-fB
 fB
 oC
-ph
+fB
+fB
+fB
+oC
+fB
 Jt
 ll
 ll
@@ -15271,7 +14828,7 @@ li
 li
 li
 Jt
-oq
+oU
 oC
 fB
 oU
@@ -15373,13 +14930,13 @@ fz
 fz
 fz
 Jt
-or
+fB
 oC
 oC
 oC
 oC
 oC
-pi
+fB
 Jt
 ll
 li
@@ -15477,11 +15034,11 @@ fz
 Jt
 oU
 fB
-oM
-oV
-pb
 fB
-pj
+oV
+fB
+fB
+fB
 Jt
 li
 li

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -4032,10 +4032,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/office)
-"ym" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
 "yn" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 4
@@ -7185,10 +7181,6 @@
 	},
 /turf/closed/ice/thin/end,
 /area/icy_caves/outpost/outside)
-"WC" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
 "WD" = (
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
@@ -19973,7 +19965,7 @@ ZT
 ZT
 ZT
 ZT
-ym
+ZT
 ST
 YW
 YW
@@ -23694,7 +23686,7 @@ by
 Lm
 Ho
 SR
-WC
+SR
 SR
 SR
 SR
@@ -25399,7 +25391,7 @@ Tu
 Tu
 Tu
 eB
-WC
+SR
 SR
 Lm
 VI

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -13,7 +13,6 @@
 /area/icy_caves/caves/crashed_ship)
 "ad" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "ae" = (
@@ -49,7 +48,6 @@
 /area/icy_caves/caves/crashed_ship)
 "al" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
 "am" = (
@@ -61,11 +59,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"ao" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "ap" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
@@ -74,15 +67,6 @@
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"ar" = (
-/obj/machinery/cryopod,
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
-"as" = (
-/obj/effect/landmark/corpsespawner/miner,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
 "at" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -90,20 +74,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"au" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
 "av" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/mainship,
@@ -168,10 +138,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
-"aJ" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "aK" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -181,19 +147,6 @@
 /obj/structure/window/framed/mainship/requisitions,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"aM" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
 "aN" = (
 /obj/machinery/light,
 /turf/open/floor/plating/mainship,
@@ -201,10 +154,6 @@
 "aO" = (
 /turf/open/floor/plating/dmg2,
 /area/icy_caves/caves/crashed_ship)
-"aP" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/northern)
 "aQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
@@ -309,19 +258,10 @@
 	dir = 10
 	},
 /area/icy_caves/caves)
-"bi" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "bj" = (
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"bk" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/plating/mainship,
-/area/icy_caves/caves/crashed_ship)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -876,10 +816,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
-"ea" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "eb" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/west)
@@ -902,10 +838,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"ei" = (
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "ej" = (
 /obj/machinery/light{
 	dir = 1
@@ -913,20 +845,6 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "em" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/south)
-"en" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
@@ -1098,13 +1016,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
-"eU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "eV" = (
 /obj/structure/ore_box,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1203,11 +1114,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/south)
-"fl" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
 "fn" = (
@@ -1569,11 +1475,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"hJ" = (
-/obj/effect/landmark/corpsespawner/miner,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/south)
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
@@ -1702,16 +1603,6 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "jM" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/tool/pickaxe/plasmacutter,
 /turf/open/floor/plating/ground/ice,
@@ -2491,7 +2382,6 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ2)
 "or" = (
-/obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
@@ -2561,19 +2451,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves/west)
-"pf" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
 "pj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -2763,16 +2640,6 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "qp" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
@@ -2826,10 +2693,6 @@
 "qH" = (
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
-"qJ" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/research)
 "qM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -3176,10 +3039,6 @@
 "si" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"sj" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/engineering)
 "sk" = (
 /obj/machinery/conveyor{
 	dir = 6
@@ -3220,10 +3079,6 @@
 /turf/open/floor/tile/dark/green2{
 	dir = 10
 	},
-/area/icy_caves/outpost/medbay)
-"sr" = (
-/obj/effect/landmark/corpsespawner/doctor,
-/turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
 "ss" = (
 /obj/item/weapon/gun/syringe,
@@ -3341,19 +3196,6 @@
 "tg" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"th" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = /obj/item/storage/backpack/satchel/norm;
-	corpsehelmet = /obj/item/clothing/head/hardhat/white;
-	corpseradio = /obj/item/radio/headset/survivor;
-	corpseshoes = /obj/item/clothing/shoes/snow;
-	corpsesuit = /obj/item/clothing/suit/storage/snow_suit;
-	corpseuniform = /obj/item/clothing/under/rank/miner;
-	mobname = "Shaft Miner";
-	name = "Shaft Miner"
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/east)
 "ti" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3471,11 +3313,6 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
-"tW" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/refinery)
 "tX" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -3612,7 +3449,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
 	},
@@ -3657,10 +3493,6 @@
 /area/icy_caves/outpost/medbay)
 "vf" = (
 /turf/closed/ice/thin/intersection,
-/area/icy_caves/outpost/outside)
-"vh" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside)
 "vi" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3715,14 +3547,6 @@
 	},
 /turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/engineering)
-"vz" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/structure/cable,
-/turf/open/floor/prison/kitchen,
-/area/icy_caves/outpost/kitchen)
 "vA" = (
 /obj/structure/dispenser,
 /obj/structure/cable,
@@ -3913,10 +3737,6 @@
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
-"xh" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "xi" = (
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/dark/green2,
@@ -4176,10 +3996,6 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"zD" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
 "zG" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -4272,15 +4088,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
-"Ah" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
-	corpsesuit = /obj/item/clothing/suit/storage/CMB;
-	corpseuniform = /obj/item/clothing/under/CM_uniform;
-	name = "Marshal Logan Bills"
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/security)
 "Ai" = (
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
@@ -4353,7 +4160,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 4
 	},
@@ -4505,11 +4311,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"By" = (
-/obj/structure/table,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/dorms)
 "Bz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4777,7 +4578,6 @@
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
 "Ef" = (
-/obj/effect/landmark/corpsespawner/security,
 /obj/item/ammo_casing,
 /obj/item/ammo_magazine/pistol/g22,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4856,13 +4656,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/medbay)
-"EK" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "EM" = (
@@ -5580,10 +5373,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"KI" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/dorms)
 "KJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow,
@@ -5668,11 +5457,6 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
 "Lt" = (
-/obj/effect/landmark/corpsespawner/miner{
-	corpseback = null;
-	corpseidjob = "Laborer";
-	name = "Colonist Kira Von"
-	},
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -5739,7 +5523,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 4
 	},
@@ -6007,10 +5790,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"Ny" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/refinery)
 "NA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/green2/corner{
@@ -6147,10 +5926,6 @@
 /obj/structure/bed/chair,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"OE" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/dark/brown2,
-/area/icy_caves/outpost/refinery)
 "OH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6410,14 +6185,6 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/refinery)
-"QT" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
 "QX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6555,7 +6322,6 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2{
 	dir = 6
 	},
@@ -6626,13 +6392,6 @@
 "Sn" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/west)
-"So" = (
-/obj/effect/landmark/corpsespawner/security{
-	corpseuniform = /obj/item/clothing/under/colonist;
-	name = "Colonist Jac Mester"
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/security)
 "Sp" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 8
@@ -7256,10 +7015,6 @@
 /obj/item/tool/kitchen/utensil/pspoon,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"Xl" = (
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/wood,
-/area/icy_caves/outpost/dorms)
 "Xn" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheeseburger,
@@ -7340,13 +7095,6 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
-"XM" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/corpsespawner/colonist,
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/icy_caves/outpost/office)
 "XN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -9965,7 +9713,7 @@ Yf
 qs
 dy
 dO
-ea
+dP
 ZW
 eT
 ff
@@ -10175,7 +9923,7 @@ oI
 pl
 pw
 OI
-pf
+oI
 oZ
 oK
 xI
@@ -10327,7 +10075,7 @@ ZU
 fT
 xI
 oJ
-au
+ax
 ax
 oI
 oI
@@ -10435,7 +10183,7 @@ lX
 TW
 eg
 ZW
-eU
+eg
 VU
 lX
 lG
@@ -10901,7 +10649,7 @@ Yf
 qs
 Di
 eb
-ei
+ZU
 ZW
 ZU
 Xu
@@ -12842,7 +12590,7 @@ gB
 wx
 QJ
 lM
-OE
+gB
 Gw
 XO
 HS
@@ -13141,7 +12889,7 @@ Gw
 zA
 uq
 uq
-Ny
+uq
 uq
 sl
 uq
@@ -13932,7 +13680,7 @@ Qf
 pO
 LI
 Nt
-Ny
+uq
 PQ
 gB
 Gw
@@ -14081,7 +13829,7 @@ Hg
 rU
 Hg
 Hg
-tW
+Hg
 vX
 zo
 Hg
@@ -16292,7 +16040,7 @@ Hf
 tg
 lk
 tg
-KI
+tg
 tg
 Hf
 KO
@@ -16320,7 +16068,7 @@ qs
 aG
 WS
 aK
-aP
+SR
 aQ
 SR
 SR
@@ -16575,7 +16323,7 @@ XO
 WY
 rz
 sd
-sr
+Ai
 sg
 EH
 wM
@@ -16593,7 +16341,7 @@ UN
 XO
 YA
 Xk
-vz
+Jv
 Qk
 Bq
 Hf
@@ -16631,7 +16379,7 @@ qs
 lX
 aH
 lG
-aM
+SR
 SR
 ok
 Fu
@@ -16726,7 +16474,7 @@ XO
 HS
 HS
 HS
-QT
+AW
 XO
 WY
 rB
@@ -16787,7 +16535,7 @@ qs
 qH
 WS
 aK
-aM
+SR
 aQ
 SR
 Sg
@@ -16829,7 +16577,7 @@ SR
 ZT
 Td
 Td
-en
+em
 eA
 eV
 Td
@@ -16943,7 +16691,7 @@ qs
 Vb
 aI
 eY
-aM
+SR
 SR
 SR
 SR
@@ -17076,7 +16824,7 @@ tg
 tg
 Zq
 wZ
-Xl
+wZ
 LC
 ND
 XO
@@ -17144,7 +16892,7 @@ Td
 ep
 eG
 eX
-fl
+em
 em
 Td
 Td
@@ -17204,7 +16952,7 @@ sA
 vb
 xw
 EH
-EK
+rW
 JM
 Ai
 WY
@@ -17549,7 +17297,7 @@ tg
 vj
 HS
 HS
-zD
+HS
 Za
 Za
 XO
@@ -17570,7 +17318,7 @@ Yf
 RN
 Vb
 lG
-aM
+SR
 aQ
 aQ
 SR
@@ -17726,7 +17474,7 @@ Yf
 qs
 lX
 eY
-aM
+SR
 SR
 SR
 SR
@@ -18154,7 +17902,7 @@ HS
 XO
 ND
 sE
-Xl
+wZ
 wZ
 Zq
 tg
@@ -18475,7 +18223,7 @@ vB
 Vo
 Zj
 Dg
-KI
+tg
 tg
 FB
 Hf
@@ -18918,7 +18666,7 @@ Za
 HS
 XO
 FZ
-XM
+kX
 Mj
 Ix
 Ff
@@ -19408,7 +19156,7 @@ Zq
 tg
 tg
 vB
-By
+Vo
 Vo
 Dg
 tg
@@ -20003,7 +19751,7 @@ Iy
 ZB
 kg
 qj
-th
+ql
 rc
 rG
 np
@@ -20036,7 +19784,7 @@ HS
 HS
 HS
 HS
-zD
+HS
 HS
 HS
 HS
@@ -20165,7 +19913,7 @@ ql
 HS
 HS
 AW
-vh
+Za
 Za
 Za
 Za
@@ -20805,7 +20553,7 @@ VM
 Ya
 YF
 uN
-So
+Ie
 Ie
 RX
 Zo
@@ -20906,7 +20654,7 @@ ZT
 ZT
 ZT
 ZT
-as
+ZT
 ZT
 ZT
 ZT
@@ -20954,7 +20702,7 @@ Za
 Za
 Za
 Za
-QT
+AW
 HS
 HS
 VN
@@ -20969,7 +20717,7 @@ Ye
 Zr
 bO
 Ie
-Ah
+Ie
 LU
 IH
 VM
@@ -21216,7 +20964,7 @@ EM
 ZB
 gq
 jA
-hJ
+hI
 ZT
 hR
 Xj
@@ -21878,7 +21626,7 @@ fC
 YS
 ro
 rM
-sj
+si
 si
 Yz
 ol
@@ -22208,7 +21956,7 @@ XO
 Za
 XO
 XO
-vh
+Za
 XO
 XO
 XO
@@ -23286,7 +23034,7 @@ hj
 mI
 XO
 Za
-xh
+Za
 Of
 Za
 rQ
@@ -23603,7 +23351,7 @@ XO
 XO
 Mh
 lN
-qJ
+qm
 AX
 Vi
 TX
@@ -23648,14 +23396,14 @@ MQ
 ow
 ow
 ow
-aJ
+ow
 MQ
 mM
 ow
 bc
 mM
 ow
-bi
+mM
 aN
 MQ
 MQ
@@ -23918,7 +23666,7 @@ Fr
 yn
 nH
 qm
-qJ
+qm
 xf
 tH
 Nq
@@ -24115,7 +23863,7 @@ Yf
 oW
 RN
 al
-ar
+ah
 ah
 MQ
 ow
@@ -24585,7 +24333,7 @@ Yf
 Yf
 qy
 aO
-aJ
+ow
 ow
 aO
 cM
@@ -25054,7 +24802,7 @@ an
 mL
 mL
 MQ
-aJ
+ow
 ow
 MQ
 MQ
@@ -25206,7 +24954,7 @@ Yf
 qs
 MQ
 ag
-ao
+aj
 av
 aC
 MQ
@@ -25371,7 +25119,7 @@ aN
 MQ
 aU
 ab
-bk
+ow
 ow
 MQ
 bz

--- a/_maps/modularmaps/lv624/internal_affairs.dmm
+++ b/_maps/modularmaps/lv624/internal_affairs.dmm
@@ -359,11 +359,6 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/internal_affairs)
 "Jr" = (
-/obj/effect/landmark/corpsespawner/bridgeofficer{
-	corpseidjob = "Bridge Officer";
-	corpseuniform = /obj/item/clothing/under/waiter;
-	name = "Mr. Johnson Telovin"
-	},
 /obj/item/tool/crowbar,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,

--- a/_maps/modularmaps/prison/civresgym.dmm
+++ b/_maps/modularmaps/prison/civresgym.dmm
@@ -53,10 +53,6 @@
 	},
 /turf/open/floor/prison/bright_clean/two,
 /area/template_noop)
-"E" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/prison/bright_clean/two,
-/area/template_noop)
 "F" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/prison/bright_clean/two,
@@ -92,7 +88,7 @@
 
 (1,1,1) = {"
 N
-E
+a
 a
 a
 a


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It just serves as a temporary fix to the issue until we get out our own map made.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It causes unnecessary trouble and forces players to waste time blocking them off.  No more "Why did xenos set up turrets in the caves" vibes / dead colonists causing issues
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
acid turret on map removed
dead bodies removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
