### PR TITLE
QOL Stopgap - Xenomorphs learn to speak common

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -104,7 +104,7 @@
 
 
 /datum/language_holder/xeno
-	languages = list(/datum/language/xenocommon)
+	languages = list(/datum/language/xenocommon, /datum/language/common)
 
 
 /datum/language_holder/universal/New()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds galcom to the xenomorphs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
At this moment, the lack of developers have somewhat halted progress.  I simply do not know how to code well enough to introduce common to xenos who gain the leadership position, so for the sake of administration (and the constant tickets asking for galcom) as well as player enjoyment?  Adding it to everyone will do, in my opinion.  Most likely temporary.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
xeno speaking common vibes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
