### PR TITLE
Mapped max squads

### DIFF
--- a/_maps/pillar_of_spring.json
+++ b/_maps/pillar_of_spring.json
@@ -2,6 +2,5 @@
     "map_name": "Pillar of Spring",
     "map_path": "map_files/Pillar_of_Spring",
     "map_file": "TGS_Pillar_of_Spring.dmm",
-    "traits": [{"Marine Main Ship": true}],
-    "squads": 2
+    "traits": [{"Marine Main Ship": true}]
 }

--- a/_maps/theseus.json
+++ b/_maps/theseus.json
@@ -2,6 +2,5 @@
     "map_name": "Theseus",
     "map_path": "map_files/Theseus",
     "map_file": "TGS_Theseus.dmm",
-    "traits": [{"Marine Main Ship": true}],
-    "squads": 2
+    "traits": [{"Marine Main Ship": true}]
 }


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically the maps had a max amount of squads that would be active which meant that only a randomly selected 2 squads would be able to be overwatched. Now you can watch everyone. Big Brother is watching.

## Why It's Good For The Game

It is. 

## Changelog
:cl:
fix: Overwatch EVERYONE.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
