### PR TITLE
Map Tweaks

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -2607,10 +2607,10 @@
 /area/bigredv2/outside/nw)
 "aka" = (
 /obj/structure/table,
-/obj/effect/spawner/random/toolbox,
-/obj/effect/spawner/random/toolbox,
 /obj/structure/cable,
 /obj/machinery/power/apc,
+/obj/structure/largecrate/random,
+/obj/structure/largecrate/random,
 /turf/open/floor,
 /area/bigredv2/outside/storage)
 "akb" = (
@@ -14017,17 +14017,17 @@
 /area/bigredv2/outside/cargo)
 "bhg" = (
 /obj/structure/table,
-/obj/effect/spawner/random/toolbox,
-/obj/effect/spawner/random/toolbox,
+/obj/structure/largecrate/random,
+/obj/structure/largecrate/random,
 /turf/open/floor,
 /area/bigredv2/outside/storage)
 "bhi" = (
 /obj/structure/table,
-/obj/effect/spawner/random/toolbox,
-/obj/effect/spawner/random/toolbox,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/largecrate/random,
+/obj/structure/largecrate/random,
 /turf/open/floor,
 /area/bigredv2/outside/storage)
 "bhj" = (
@@ -14431,9 +14431,9 @@
 /area/bigredv2/outside/c)
 "biW" = (
 /obj/structure/table,
-/obj/effect/spawner/random/toolbox,
-/obj/effect/spawner/random/toolbox,
 /obj/machinery/light,
+/obj/structure/largecrate/random,
+/obj/structure/largecrate/random,
 /turf/open/floor,
 /area/bigredv2/outside/storage)
 "biY" = (

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -1399,6 +1399,10 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"hJ" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/tile/dark/yellow2,
+/area/icy_caves/outpost/engineering)
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
@@ -3391,6 +3395,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/tile/dark/yellow2,
 /area/icy_caves/outpost/engineering)
 "vA" = (
@@ -6986,6 +6991,12 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
+/area/icy_caves/outpost/security)
+"YZ" = (
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
 /area/icy_caves/outpost/security)
 "Za" = (
 /turf/open/floor/plating/ground/snow/layer0,
@@ -20716,7 +20727,7 @@ Ie
 RX
 Zo
 Pd
-UQ
+YZ
 RX
 wk
 Mt
@@ -21007,7 +21018,7 @@ rH
 si
 sv
 tm
-ol
+hJ
 yC
 Bs
 aW


### PR DESCRIPTION
Adds two engineer lockers and one security locker to Icy Caves
Replaces toolboxes with random supply crates in emergency storage on Big Red