### PR TITLE
Barrenquilla & Magmoor Minor Changes

### DIFF
--- a/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
+++ b/_maps/map_files/Barrenquilla_Mining/Barrenquilla_Mining_Facility.dmm
@@ -193,7 +193,7 @@
 /turf/open/lavaland/basalt,
 /area/barren/cave/southeast)
 "aW" = (
-/obj/machinery/light_construct{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mainship/black/full,
@@ -656,12 +656,11 @@
 /turf/open/lavaland/basalt,
 /area/barren/cave/southwest)
 "dA" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/razorwire,
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
+/turf/open/floor/wood,
+/area/bigredv2/outside/general_offices)
 "dB" = (
 /obj/structure/table/reinforced/prison,
 /obj/item/paper,
@@ -879,7 +878,6 @@
 /obj/item/clothing/under/rank/miner,
 /obj/item/clothing/suit/storage/marine/veteran/mercenary/miner,
 /obj/item/clothing/suit/storage/marine/veteran/mercenary/miner,
-/obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/barren/civilian/workdorm)
 "eA" = (
@@ -1084,11 +1082,10 @@
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
 "fI" = (
-/obj/structure/barricade/metal{
-	dir = 4
-	},
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/bigredv2/outside/general_offices)
 "fK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1380,15 +1377,10 @@
 /turf/closed/wall,
 /area/barren/cave/west)
 "he" = (
-/obj/structure/barricade/guardrail{
-	dir = 4;
-	pixel_y = 7
-	},
-/obj/structure/barricade/metal{
-	dir = 1
-	},
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/grimy,
+/area/barren/civilian/workdorm)
 "hg" = (
 /obj/structure/bed/chair/sofa/right,
 /turf/open/floor/carpet{
@@ -1556,10 +1548,10 @@
 /turf/open/lavaland/catwalk,
 /area/barren/cave/east)
 "hW" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
+/obj/structure/table/woodentable,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood,
+/area/barren/misc/shack)
 "ib" = (
 /obj/structure/table,
 /obj/item/toy/deck,
@@ -1744,6 +1736,7 @@
 /area/bigredv2/outside/general_offices)
 "iR" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/barren/misc/shack)
 "iS" = (
@@ -1875,21 +1868,11 @@
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/barren/medical/research)
-"jL" = (
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "jM" = (
 /obj/machinery/door/poddoor/mainship,
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
 /area/barren/misc/crashed)
-"jN" = (
-/obj/item/assembly/mousetrap/armed,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "jO" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor,
@@ -1935,12 +1918,6 @@
 /obj/structure/barricade/guardrail,
 /turf/open/lavaland/catwalk,
 /area/barren/cave/south)
-"jZ" = (
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "ka" = (
 /mob/living/simple_animal/hostile/construct/wraith,
 /turf/open/lavaland/basalt,
@@ -2000,7 +1977,6 @@
 /area/barren)
 "km" = (
 /obj/structure/toilet,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/barren/misc/shack)
 "kn" = (
@@ -2042,12 +2018,6 @@
 /obj/item/clothing/mask/cigarette/kelo,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
-"kw" = (
-/obj/item/stack/sheet/wood{
-	amount = 50
-	},
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "kx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2058,16 +2028,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/barren/cave/southwest)
-"kz" = (
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/barren/misc/shack)
 "kA" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/marking,
@@ -2081,6 +2041,8 @@
 "kD" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp,
+/obj/item/flashlight/lantern,
 /turf/open/floor/wood/broken,
 /area/barren/misc/shack)
 "kE" = (
@@ -2108,6 +2070,7 @@
 /area/barren/misc/alienstorage)
 "kJ" = (
 /obj/structure/bed/alien,
+/obj/item/bedsheet/green,
 /turf/open/floor/wood,
 /area/barren/misc/shack)
 "kK" = (
@@ -2255,10 +2218,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/tile/dark2,
 /area/barren/engie/engine)
-"lv" = (
-/obj/structure/razorwire,
-/turf/open/lavaland/basalt/glowing,
-/area/barren/cave/southeast)
 "lx" = (
 /obj/machinery/landinglight/ds2/delaythree,
 /obj/effect/decal/warning_stripes/thin,
@@ -2570,11 +2529,6 @@
 	},
 /turf/open/lavaland/catwalk,
 /area/barren/cave/south)
-"nb" = (
-/obj/machinery/floodlight,
-/obj/structure/cable,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "nd" = (
 /obj/structure/bed/alien,
 /obj/item/bedsheet,
@@ -2672,14 +2626,6 @@
 	dir = 4
 	},
 /area/barren)
-"ny" = (
-/obj/structure/barricade/guardrail{
-	dir = 4;
-	pixel_y = 7
-	},
-/obj/structure/razorwire,
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
 "nz" = (
 /obj/structure/window/framed/colony,
 /obj/structure/sign/heat,
@@ -2727,13 +2673,6 @@
 	dir = 1
 	},
 /area/barren/civilian)
-"nI" = (
-/obj/structure/cable,
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
 "nJ" = (
 /obj/item/tool/pickaxe/plasmacutter,
 /turf/open/lavaland/basalt,
@@ -2789,13 +2728,6 @@
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/barren/civilian/cook)
-"nY" = (
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
-/obj/structure/barricade/wooden,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "nZ" = (
 /obj/structure/flora/pottedplant/twentyone,
 /obj/effect/decal/cleanable/cobweb2,
@@ -3016,10 +2948,8 @@
 /turf/open/floor/plating,
 /area/barren/cave/lz2)
 "pr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/structure/mineral_door/wood/open,
+/turf/open/floor/wood,
 /area/barren/misc/shack)
 "pu" = (
 /turf/open/floor/plating/dmg1,
@@ -3626,13 +3556,6 @@
 	dir = 8
 	},
 /area/barren/security)
-"tb" = (
-/obj/structure/barricade/wooden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/barren/misc/shack)
 "tc" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/mainship{
@@ -3718,12 +3641,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/barren/civilian/cook)
-"tx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/barren/misc/shack)
 "ty" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/mop,
@@ -3766,13 +3683,6 @@
 	dir = 5
 	},
 /area/barren/security)
-"tJ" = (
-/obj/item/stack/sheet/wood{
-	amount = 50
-	},
-/obj/structure/cable,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "tL" = (
 /obj/structure/cable,
 /turf/open/floor/grimy,
@@ -3889,10 +3799,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "uu" = (
-/obj/structure/table/woodentable,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/effect/landmark/weapon_spawn/tier2_weapon_spawn,
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood,
 /area/barren/misc/shack)
 "uv" = (
 /obj/structure/table/reinforced,
@@ -4030,15 +3939,6 @@
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
-"vk" = (
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/barren/misc/shack)
 "vl" = (
 /obj/machinery/door/airlock/mainship/security/free_access{
 	name = "Light Armory"
@@ -4219,13 +4119,6 @@
 	},
 /turf/open/lavaland/lava/side,
 /area/barren)
-"ww" = (
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/barren/misc/shack)
 "wz" = (
 /obj/structure/barricade/guardrail{
 	dir = 8
@@ -4385,19 +4278,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/barren/civilian/workdorm)
 "xr" = (
-/obj/structure/barricade/wooden{
-	dir = 8
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
 	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/turf/open/floor/wood,
 /area/barren/misc/shack)
 "xs" = (
 /obj/structure/table/woodentable,
-/obj/effect/landmark/weapon_spawn/tier2_weapon_spawn,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/item/flashlight/lantern,
+/turf/open/floor/wood,
 /area/barren/misc/shack)
 "xt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4631,10 +4520,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/vault,
 /area/barren/civilian)
-"zc" = (
-/obj/structure/razorwire,
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
 "zd" = (
 /obj/item/trash/cigbutt/cigarbutt,
 /obj/effect/decal/cleanable/dirt,
@@ -5037,6 +4922,7 @@
 "Bz" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/structure/bed/alien,
+/obj/item/bedsheet/orange,
 /turf/open/floor/wood,
 /area/barren/misc/shack)
 "BA" = (
@@ -5195,11 +5081,6 @@
 /obj/item/tool/pickaxe/plasmacutter,
 /turf/open/floor/tile/dark2,
 /area/barren/misc/refinery)
-"Ch" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/barren/misc/shack)
 "Ci" = (
 /obj/effect/decal/siding{
 	dir = 1
@@ -5260,12 +5141,6 @@
 	},
 /turf/open/floor,
 /area/storage/testroom)
-"CA" = (
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
 "CB" = (
 /obj/item/trash/hotdog,
 /obj/structure/cable,
@@ -5477,14 +5352,8 @@
 /area/barren/security)
 "DP" = (
 /obj/structure/closet/crate/plastic,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/obj/item/ore/phoron,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/weapon_spawn/tier1_weapon_spawn,
+/turf/open/floor/wood,
 /area/barren/misc/shack)
 "DR" = (
 /obj/effect/decal/woodsiding{
@@ -6200,6 +6069,7 @@
 "Ib" = (
 /obj/structure/mineral_door/wood/open,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/mineral_door/wood,
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
@@ -6877,15 +6747,6 @@
 /obj/machinery/computer/nuke_disk_generator/green,
 /turf/open/floor/prison/sterilewhite,
 /area/barren/medical/research)
-"LX" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
-	},
-/obj/structure/barricade/metal{
-	dir = 1
-	},
-/turf/open/lavaland/catwalk,
-/area/barren/cave/south)
 "LZ" = (
 /obj/machinery/door/poddoor/mainship/indestructible{
 	id = "secure_blast4";
@@ -7278,11 +7139,6 @@
 	},
 /turf/open/floor/tile/hydro,
 /area/barren/civilian/botany)
-"Oz" = (
-/obj/machinery/power/port_gen/pacman/mobile_power,
-/obj/structure/cable,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "OB" = (
 /obj/structure/cable,
 /obj/structure/window/framed/colony/reinforced,
@@ -7923,9 +7779,8 @@
 /turf/closed/wall/mainship/outer/reinforced,
 /area/storage/testroom)
 "SA" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood,
 /area/barren/misc/shack)
 "SC" = (
 /turf/open/floor/wood{
@@ -8235,10 +8090,6 @@
 /obj/structure/closet/secure_closet/medical_doctor,
 /turf/open/floor/freezer,
 /area/barren/medical/chemistry)
-"UQ" = (
-/obj/structure/barricade/metal,
-/turf/open/floor/plating,
-/area/barren/cave/south)
 "US" = (
 /turf/open/lavaland/lava/side{
 	dir = 1
@@ -8254,10 +8105,6 @@
 	},
 /turf/open/floor/wood,
 /area/barren/security)
-"UW" = (
-/obj/effect/landmark/weapon_spawn/tier1_weapon_spawn,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "UX" = (
 /obj/effect/decal/woodsiding{
 	dir = 1
@@ -8428,10 +8275,10 @@
 /turf/open/lavaland/basalt,
 /area/barren/cave/west)
 "VY" = (
-/obj/machinery/light_construct{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/barren/security)
 "VZ" = (
@@ -8516,10 +8363,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/barren/medical)
-"WD" = (
-/obj/structure/lattice,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "WF" = (
 /obj/structure/barricade/guardrail,
 /obj/structure/barricade/guardrail{
@@ -8563,10 +8406,6 @@
 /obj/machinery/floodlight/outpost,
 /turf/open/lavaland/basalt,
 /area/barren/cave/south)
-"WO" = (
-/obj/structure/razorwire,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "WR" = (
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor,
@@ -8634,10 +8473,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/outside/general_offices)
-"Xo" = (
-/obj/structure/cable,
-/turf/open/lavaland/basalt,
-/area/barren/cave/southeast)
 "Xp" = (
 /obj/structure/barricade/guardrail{
 	dir = 4;
@@ -21481,7 +21316,7 @@ ig
 sU
 Gj
 Gj
-Sp
+bm
 Bi
 rK
 rK
@@ -26383,11 +26218,11 @@ DY
 IM
 IM
 kh
-PT
+dA
 DG
 FB
 OZ
-RL
+fI
 Dc
 HM
 HM
@@ -43402,7 +43237,7 @@ Gs
 CS
 TO
 QJ
-zc
+OR
 Wu
 OR
 aE
@@ -43659,8 +43494,8 @@ CS
 TO
 TO
 QJ
-CA
-nI
+OR
+Wu
 OR
 aE
 TO
@@ -44169,8 +44004,8 @@ mZ
 mZ
 mZ
 mZ
-dA
-LX
+mZ
+mZ
 mZ
 mZ
 xb
@@ -44682,8 +44517,8 @@ DH
 OR
 OR
 DH
-ny
-he
+DH
+DH
 DH
 DH
 DH
@@ -44692,8 +44527,8 @@ xX
 xb
 xb
 xb
-UQ
-zc
+xb
+OR
 OR
 OR
 xb
@@ -44949,7 +44784,7 @@ xX
 xb
 xb
 xb
-UQ
+xb
 OR
 OR
 OR
@@ -46486,7 +46321,7 @@ BI
 jJ
 TO
 Pv
-fI
+OR
 OR
 Xk
 gu
@@ -46743,9 +46578,9 @@ TO
 TO
 TO
 QJ
-zc
 OR
-zc
+OR
+OR
 aE
 TO
 TO
@@ -49821,14 +49656,14 @@ AX
 mo
 ZS
 ZS
-wj
-wj
+kH
+kH
 ZS
 ZS
 ZS
 ZS
-wj
-wj
+kH
+kH
 wj
 wj
 kH
@@ -50084,11 +49919,11 @@ ZS
 ZS
 ZS
 ZS
-kH
-WD
-kH
-kH
-kH
+wj
+wj
+wj
+wj
+wj
 wj
 wj
 ZS
@@ -50342,7 +50177,7 @@ ZS
 ZS
 ZS
 wj
-jZ
+wj
 wj
 wj
 wj
@@ -50606,7 +50441,7 @@ wj
 wj
 wj
 wj
-jN
+wj
 wj
 ZS
 ZS
@@ -50858,7 +50693,7 @@ ZS
 ZS
 wj
 wj
-jN
+wj
 wj
 wj
 wj
@@ -51367,7 +51202,7 @@ wj
 wj
 wj
 wj
-WO
+wj
 ZS
 ZS
 ZS
@@ -51623,8 +51458,8 @@ wj
 wj
 wj
 ZS
-jZ
-jZ
+kH
+kH
 ZS
 ZS
 ZS
@@ -51883,7 +51718,7 @@ ZS
 wj
 wj
 wj
-UW
+wj
 ZS
 ZS
 wj
@@ -52138,7 +51973,6 @@ wj
 ZS
 ZS
 wj
-jN
 wj
 wj
 wj
@@ -52149,9 +51983,10 @@ wj
 wj
 wj
 wj
-lv
-WO
-WO
+wj
+QC
+wj
+wj
 wj
 wj
 ZS
@@ -52405,10 +52240,10 @@ wj
 ZS
 ZS
 wj
-jZ
-jZ
-jZ
-nY
+wj
+wj
+wj
+wj
 wj
 aV
 ZS
@@ -53141,7 +52976,7 @@ EF
 EF
 dH
 ez
-CU
+he
 fV
 Zi
 Mn
@@ -53179,7 +53014,7 @@ iR
 Vh
 wj
 wj
-LQ
+wj
 LQ
 LQ
 LQ
@@ -53432,13 +53267,13 @@ wj
 ZS
 LQ
 LQ
-Vh
+uN
 wj
 wj
 wj
 wj
 LQ
-kz
+ns
 ns
 SA
 LQ
@@ -53695,7 +53530,7 @@ wj
 wj
 Vh
 iR
-iR
+ns
 ns
 ns
 LQ
@@ -54200,7 +54035,7 @@ wj
 wj
 wj
 wj
-jL
+wj
 wj
 wj
 QC
@@ -54456,13 +54291,13 @@ wj
 wj
 wj
 wj
-WO
-jL
 wj
 wj
 wj
-tJ
-nb
+wj
+wj
+wj
+wj
 wj
 wj
 wj
@@ -54718,7 +54553,7 @@ ZS
 wj
 wj
 wj
-Xo
+wj
 wj
 wj
 wj
@@ -54975,8 +54810,8 @@ ZS
 ZS
 wj
 wj
-Xo
-kw
+wj
+wj
 wj
 wj
 ph
@@ -55226,13 +55061,13 @@ ZS
 ZS
 ZS
 ZS
-ZS
-ZS
 LQ
-ZS
-ZS
+LQ
+LQ
+LQ
+LQ
 wj
-Xo
+wj
 wj
 wj
 wj
@@ -55485,11 +55320,11 @@ ZS
 ZS
 LQ
 DP
-iR
-iR
+ns
+ns
 Ib
 wj
-Xo
+wj
 QC
 wj
 wj
@@ -55727,8 +55562,8 @@ wj
 wj
 wj
 kH
-WO
-jL
+wj
+wj
 wj
 wj
 wj
@@ -55742,11 +55577,11 @@ ZS
 ZS
 LQ
 PY
-SA
-ZS
-ZS
+ns
+LQ
+LQ
 wj
-Xo
+wj
 wj
 wj
 wj
@@ -55985,9 +55820,9 @@ wj
 wj
 kH
 wj
-jL
 wj
-jN
+wj
+wj
 aV
 wj
 wj
@@ -55997,13 +55832,13 @@ wj
 ZS
 ZS
 ZS
-ZS
-ZS
 LQ
-ZS
-ZS
+LQ
+LQ
+LQ
 wj
-Xo
+wj
+wj
 wj
 wj
 wj
@@ -56257,17 +56092,17 @@ ZS
 ZS
 ZS
 ZS
-Oz
-Xo
-Xo
-hW
+wj
+wj
+wj
+wj
 wj
 wj
 wj
 wj
 LQ
-tb
-vk
+ns
+ns
 Bz
 LQ
 GS
@@ -56498,8 +56333,6 @@ wj
 wj
 wj
 kH
-WO
-jL
 wj
 wj
 wj
@@ -56509,23 +56342,25 @@ wj
 wj
 wj
 wj
-WO
-jL
 wj
 wj
 wj
 wj
 wj
 wj
-jN
+wj
+wj
+wj
+wj
+wj
 wj
 wj
 wj
 wj
 LQ
-tx
-ww
-Ch
+ns
+ns
+ns
 LQ
 GS
 aI
@@ -56755,8 +56590,6 @@ ZS
 wj
 wj
 kH
-WO
-jL
 wj
 wj
 wj
@@ -56766,8 +56599,10 @@ wj
 wj
 wj
 wj
-WO
-jL
+wj
+wj
+wj
+wj
 wj
 wj
 wj
@@ -57013,11 +56848,11 @@ ZS
 ZS
 ZS
 ZS
-jL
+wj
 wj
 wj
 QC
-jN
+wj
 wj
 wj
 wj
@@ -57039,7 +56874,7 @@ wj
 LQ
 uu
 xs
-uu
+hW
 LQ
 GS
 aI
@@ -57536,8 +57371,8 @@ wj
 wj
 wj
 wj
-lv
-jL
+QC
+wj
 wj
 wj
 wj
@@ -57793,8 +57628,8 @@ wj
 wj
 wj
 wj
-WO
-jL
+wj
+wj
 wj
 wj
 wj
@@ -58050,8 +57885,8 @@ ZS
 wj
 wj
 wj
-WO
-jL
+wj
+wj
 wj
 wj
 wj

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -30,10 +30,6 @@
 	dir = 4
 	},
 /area/magmoor/compound/northeast)
-"act" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/north)
 "acH" = (
 /turf/closed/wall,
 /area/storage/testroom)
@@ -3334,10 +3330,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/magmoor/mining/garage)
-"cQP" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/northwest)
 "cQZ" = (
 /obj/structure/rack,
 /obj/item/tool/pickaxe/drill,
@@ -7399,10 +7391,6 @@
 	dir = 1
 	},
 /area/magmoor/compound/northeast)
-"fIc" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/west)
 "fIf" = (
 /obj/structure/barricade/guardrail{
 	dir = 1
@@ -12122,10 +12110,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/mainship/sterile/side,
 /area/magmoor/medical/patient)
-"jpv" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/northeast)
 "jpE" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15258,10 +15242,6 @@
 	dir = 1
 	},
 /area/magmoor/security/storage)
-"lNt" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/central)
 "lNJ" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/mainship/cargo,
@@ -15443,10 +15423,6 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/east)
-"lYH" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/mainship/sterile/dark,
-/area/magmoor/research/containment)
 "lZd" = (
 /obj/structure/lattice,
 /turf/open/lavaland/lava/single/middle{
@@ -25843,12 +25819,6 @@
 	dir = 9
 	},
 /area/magmoor/compound/northwest)
-"tyC" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/lavaland/basalt/cave/corner{
-	dir = 1
-	},
-/area/magmoor/cave/northeast)
 "tyL" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -36745,7 +36715,7 @@ aum
 qlL
 bCo
 pGg
-cQP
+pGg
 pGg
 rwF
 rwF
@@ -37231,7 +37201,7 @@ kal
 tvK
 rwF
 rwF
-fIc
+tvK
 kal
 fHm
 kal
@@ -41394,7 +41364,7 @@ nqC
 pGg
 pGg
 rRl
-cQP
+pGg
 pGg
 cdN
 bid
@@ -51185,7 +51155,7 @@ qkn
 aMD
 ebU
 aMD
-act
+aMD
 aMD
 dTv
 dSS
@@ -53996,7 +53966,7 @@ vMR
 fcj
 vns
 vns
-lNt
+vns
 vns
 cUK
 cUK
@@ -56535,7 +56505,7 @@ aNx
 aNx
 aqg
 idd
-jpv
+idd
 idd
 idd
 jUo
@@ -61433,7 +61403,7 @@ utw
 cuI
 bax
 veX
-tyC
+pbk
 bNO
 bWx
 hVA
@@ -66084,7 +66054,7 @@ jUo
 jUo
 drL
 azI
-lYH
+mmA
 dWY
 mmA
 mmA


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Deletes some random items from the Barrenquilla caves (mousetraps, razorwires and random cades), re-furbishes the SE cave shacks and makes it something other than just ruins for looting, while also taking that one survivor spawner out of the closet. Also removes Magmoor's acid turrets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gotta make the maps better a step at a time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Barrenquilla's shacks are actually usable now
del: Removed random stuff from the Barrenquilla caves like razorwire and cades, as well as random mousetraps.
fix: Survivors spawning at the eastern outpost shouldn't spawn in a locker now.
del: Removed Magmoor's acid turrets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
