### PR TITLE
Marine/Xenomorph QOL and Balance

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define LIMB_METAL_AMOUNT 125
 
 //How long it takes for a human to become undefibbable
-#define TIME_BEFORE_DNR 150 //In life ticks, multiply by 2 to have seconds
+#define TIME_BEFORE_DNR 600 //In life ticks, multiply by 2 to have seconds
 
 
 //species_flags

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -110,13 +110,13 @@
 	config_entry_value = FALSE
 
 /datum/config_entry/number/marine_respawn
-	config_entry_value = 30 MINUTES
-	max_val = 30 MINUTES
+	config_entry_value = 5 MINUTES
+	max_val = 5 MINUTES
 	min_val = 0
 
 /datum/config_entry/number/xeno_respawn
-	config_entry_value = 30 MINUTES
-	max_val = 30 MINUTES
+	config_entry_value = 5 MINUTES
+	max_val = 5 MINUTES
 	min_val = 0
 
 /datum/config_entry/flag/account_age_restriction

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -21,7 +21,7 @@
 
 	var/deploy_time_lock = 15 MINUTES
 	///The respawn time for marines
-	var/respawn_time = 30 MINUTES
+	var/respawn_time = 5 MINUTES
 
 //Distress call variables.
 	var/list/datum/emergency_call/all_calls = list() //initialized at round start and stores the datums.

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -493,6 +493,28 @@
 			M.show_inv(src)
 
 
+/mob/living/carbon/xenomorph/stripPanelUnequip(obj/item/I, mob/M, slot_to_process)
+	if(I.flags_item & ITEM_ABSTRACT)
+		return
+	if(I.flags_item & NODROP)
+		to_chat(src, span_warning("You can't remove \the [I.name], it appears to be stuck!"))
+		return
+	log_combat(src, M, "attempted to slash off [key_name(I)] ([slot_to_process])")
+
+	M.visible_message(span_danger("[src] tries to slash off [M]'s [I.name]."), \
+					span_userdanger("[src] tries to slash off [M]'s [I.name]."), null, 5)
+	if(do_mob(src, M, HUMAN_STRIP_DELAY, BUSY_ICON_HOSTILE))
+		if(Adjacent(M) && I && I == M.get_item_by_slot(slot_to_process))
+			M.dropItemToGround(I)
+			log_combat(src, M, "removed [key_name(I)] ([slot_to_process])")
+			if(isidcard(I))
+				message_admins("[ADMIN_TPMONTY(src)] took the [I] of [ADMIN_TPMONTY(M)].")
+
+	if(M)
+		if(interactee == M && Adjacent(M))
+			M.show_inv(src)
+
+
 /mob/living/carbon/human/stripPanelEquip(obj/item/I, mob/M, slot_to_process)
 	if(I && !(I.flags_item & ITEM_ABSTRACT))
 		if(I.flags_item & NODROP)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -48,9 +48,8 @@
 		/datum/action/xeno_action/activable/gravity_crush_lesser,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
 		/datum/action/xeno_action/activable/nightfall,
-		/datum/action/xeno_action/activable/gravity_crush,
-		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/activable/nightfall/lesser,
+		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/activable/rally_hive,
 	)
 
@@ -86,9 +85,9 @@
 		/datum/action/xeno_action/activable/devour,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/plant_weeds,
-		/datum/action/xeno_action/activable/nightfall/lesser,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
 		/datum/action/xeno_action/activable/nightfall,
+		/datum/action/xeno_action/activable/nightfall/lesser,
 		/datum/action/xeno_action/activable/gravity_crush,
 		/datum/action/xeno_action/activable/gravity_crush_lesser,
 		/datum/action/xeno_action/toggle_pheromones,
@@ -130,12 +129,11 @@
 		/datum/action/xeno_action/activable/devour,
 		/datum/action/xeno_action/activable/cocoon,
 		/datum/action/xeno_action/plant_weeds,
-		/datum/action/xeno_action/activable/nightfall/lesser,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
 		/datum/action/xeno_action/activable/nightfall,
+		/datum/action/xeno_action/activable/nightfall/lesser,
 		/datum/action/xeno_action/activable/gravity_crush,
 		/datum/action/xeno_action/activable/gravity_crush_lesser,
-		/datum/action/xeno_action/psychic_summon,
 		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/activable/rally_hive,
 	)
@@ -182,7 +180,6 @@
 		/datum/action/xeno_action/activable/nightfall,
 		/datum/action/xeno_action/activable/gravity_crush,
 		/datum/action/xeno_action/activable/gravity_crush_lesser,
-		/datum/action/xeno_action/psychic_summon,
 		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/activable/rally_hive,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -76,7 +76,7 @@
 		counter += 2.5 //Accelerates larval growth somewhat. You don't want this stuff in your body.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/consumable/larvajelly))
-		counter += 10 //Accelerates larval growth massively. Voluntarily drinking larval jelly while infected is straight-up suicide. Larva hits Stage 5 in exactly ONE minute.
+		counter += 5 //Accelerates larval growth massively. Voluntarily drinking larval jelly while infected is straight-up suicide. Larva hits Stage 5 in exactly ONE minute.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/medicine/larvaway))
 		counter -= 1 //Halves larval growth progress, for some tradeoffs. Larval toxin purges this

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -82,7 +82,7 @@
 		counter -= 1 //Halves larval growth progress, for some tradeoffs. Larval toxin purges this
 
 
-	if(stage < 5 && counter >= 120)
+	if(stage < 5 && counter >= 1200)
 		counter = 0
 		stage++
 		log_combat(affected_mob, null, "had their embryo advance to stage [stage]")
@@ -206,6 +206,8 @@
 
 	if((locate(/obj/structure/bed/nest) in loc) && hive.living_xeno_queen?.z == loc.z)
 		burrow()
+	else
+		addtimer(CALLBACK(src, .proc/burrow), 5 MINUTES)
 
 
 /mob/living/proc/emote_burstscream()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -480,16 +480,13 @@
 	. = ..()
 	if(.)
 		return
-	if(!ismob(dropping) || isxeno(user) || isxeno(dropping))
+	if(!ismob(dropping))
 		return
 	// If not dragged onto myself or dragging my own sprite onto myself
 	if(user != src || dropping == user)
 		return
 	var/mob/dragged = dropping
 	dragged.show_inv(user)
-
-/mob/living/carbon/xenomorph/MouseDrop_T(atom/dropping, atom/user)
-	return
 
 
 /mob/living/start_pulling(atom/movable/AM, suppress_message = FALSE)

--- a/code/modules/reagents/reagents/food.dm
+++ b/code/modules/reagents/reagents/food.dm
@@ -416,6 +416,7 @@
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
 			var/list/genits = H.adjust_arousal(current_cycle, aphro = TRUE)
+			H.lust += 2
 			for(var/g in genits)
 				var/datum/internal_organ/genital/G = g
 				to_chat(L, "<span class='userlove'>[G.arousal_verb]!</span>")
@@ -434,6 +435,7 @@
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
 			var/list/genits = H.adjust_arousal(current_cycle, aphro = TRUE)
+			H.lust += 1
 			for(var/g in genits)
 				var/datum/internal_organ/genital/G = g
 				to_chat(L, "<span class='userlove'>[G.arousal_verb]!</span>")

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -478,15 +478,17 @@
 	var/stamina_loss_limit = L.maxHealth * 2
 	L.adjustStaminaLoss(min(power, max(0, stamina_loss_limit - L.staminaloss))) //If we're under our stamina_loss limit, apply the difference between our limit and current stamina damage or power, whichever's less
 
-/* Commented out because... this ended up being insane. Instant death on hug regardless past 2 stings unless they took combat stim
 	var/stamina_excess_damage = (L.staminaloss + power) - stamina_loss_limit
 	if(stamina_excess_damage > 0) //If we exceed maxHealth * 2 stamina damage, apply any excess as toxloss and oxyloss
+		L.Unconscious(stamina_excess_damage * 2) //Changes death to unconsciousness instead
+		/*
 		L.adjustToxLoss(stamina_excess_damage * 0.5)
 		L.adjustOxyLoss(stamina_excess_damage * 0.5)
 		L.Losebreath(2) //So the oxy loss actually means something.
+		*/
 
 	L.stuttering = max(L.stuttering, 1)
-*/
+
 	if(current_cycle < 21) //Additional effects at higher cycles
 		return ..()
 


### PR DESCRIPTION
- Xenomorph can now strip marines
- Neurotoxin OD is back, but simply renders someone unconscious instead of killing them
- Larva now take 10 times as long to gestate. This is a balance chance because Xenos have ready access to growth jelly, reusable hosts, and being able to impregnate two holes at once.
- SSD Larva burrow after 5 minutes after being born
- Growth jelly's effect on larva gestation halved (because Xenos have ready access to it)
- Defib timer for Marines set from 5 minutes to 20 minutes
- Larva jelly slightly increases arousal
- King can no longer summon the entire hive